### PR TITLE
Bug 1 - AI Insights Status Fails to Update Without Manual Refresh

### DIFF
--- a/backend/migrations/1774900000000_add-submitted-at-to-projects.js
+++ b/backend/migrations/1774900000000_add-submitted-at-to-projects.js
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn('projects', {
+    submitted_at: { type: 'timestamp', notNull: false },
+  });
+
+  // Backfill: existing completed projects use updated_at as their best
+  // available submission timestamp so historical reports keep rendering a date.
+  pgm.sql(
+    `UPDATE projects SET submitted_at = updated_at WHERE status = 'completed' AND submitted_at IS NULL`,
+  );
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn('projects', 'submitted_at');
+};

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1227,11 +1227,14 @@ router.post(
         }
     });
 
-    // Return immediately
-    res.json({ 
-      success: true, 
-      jobId, 
+    // Return immediately. Surface already-cached insights so the client can
+    // render them without waiting for the new job to finish regenerating
+    // the missing (or previously-failed) domains.
+    res.json({
+      success: true,
+      jobId,
       status: 'processing',
+      existingInsights: cachedAllowed,
       message: "Insights generation started. Please poll status."
     });
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -431,7 +431,10 @@ async function computeProjectResults(
       : 0;
 
     const domainTotalQuestions = practices.reduce((sum: number, p: any) => sum + p.totalQuestions, 0);
-    if (!domain.isPremium) {
+    // Mirror the `relevantDomains` filter below: premium users count premium
+    // domains too, otherwise Questions Analyzed undercounts what was actually
+    // scored into overallMaturityScore.
+    if (isPremium || !domain.isPremium) {
       totalQuestions += domainTotalQuestions;
     }
 
@@ -526,6 +529,11 @@ router.get(
     try {
       const { projectId } = req.params;
       const project = req.project as { id: string; name: string; status: string; version_id: string | null };
+
+      if (project.status !== 'completed') {
+        return res.status(404).json({ error: "Project has not been submitted yet" });
+      }
+
       const isPremium = isPremiumUser((req.project as any).owner_subscription);
 
       const { domains, overall } = await computeProjectResults(
@@ -547,7 +555,7 @@ router.get(
         "SELECT updated_at FROM projects WHERE id = $1",
         [projectId]
       );
-      const submittedAt = project.status === 'completed' && submittedRow.rows[0]?.updated_at
+      const submittedAt = submittedRow.rows[0]?.updated_at
         ? new Date(submittedRow.rows[0].updated_at).toISOString()
         : null;
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -509,12 +509,16 @@ router.post(
       },
     });
 
+    const submitterRole = req.projectMembership?.role;
+    const canGenerateInsights = submitterRole === "OWNER" || submitterRole === "EDITOR";
+
     res.json({
       message: "Project submitted successfully",
       project: result.rows[0],
       results: { domains, overall },
       capabilities: {
         premiumInsights: isPremium,
+        canGenerateInsights,
       },
     });
   } catch (error) {
@@ -571,6 +575,13 @@ router.get(
         ? new Date(submittedRow.rows[0].submitted_at).toISOString()
         : null;
 
+      // Insight generation is a write (mutates project_insights) and is
+      // restricted to OWNER/EDITOR by the /generate-insights route. Surface
+      // that as a capability so VIEWERs don't auto-trigger a request that
+      // will only ever 403.
+      const viewerRole = req.projectMembership?.role;
+      const canGenerateInsights = viewerRole === "OWNER" || viewerRole === "EDITOR";
+
       res.json({
         project,
         results: { domains, overall },
@@ -581,6 +592,7 @@ router.get(
         // collaborators on a premium owner's project still get full insights.
         capabilities: {
           premiumInsights: isPremium,
+          canGenerateInsights,
         },
       });
     } catch (error) {

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -509,7 +509,12 @@ router.post(
       },
     });
 
-    const submitterRole = req.projectMembership?.role;
+    // Same normalization getMembership uses: legacy projects without a
+    // project_members row still grant OWNER to the project's user_id, so
+    // canGenerateInsights must mirror that fallback.
+    const submitterRole =
+      req.projectMembership?.role ??
+      (req.user?.id === (req.project as any)?.user_id ? "OWNER" : undefined);
     const canGenerateInsights = submitterRole === "OWNER" || submitterRole === "EDITOR";
 
     res.json({
@@ -578,8 +583,12 @@ router.get(
       // Insight generation is a write (mutates project_insights) and is
       // restricted to OWNER/EDITOR by the /generate-insights route. Surface
       // that as a capability so VIEWERs don't auto-trigger a request that
-      // will only ever 403.
-      const viewerRole = req.projectMembership?.role;
+      // will only ever 403. Same owner fallback as getMembership: legacy
+      // projects without a project_members row still treat the project's
+      // user_id as OWNER.
+      const viewerRole =
+        req.projectMembership?.role ??
+        (req.user?.id === (req.project as any)?.user_id ? "OWNER" : undefined);
       const canGenerateInsights = viewerRole === "OWNER" || viewerRole === "EDITOR";
 
       res.json({
@@ -1031,8 +1040,21 @@ const generateInsightsAsync = async (
       return;
     }
 
-    // Initialize insights with existing ones so we don't regenerate them
-    const insights: Record<string, string> = { ...existingInsights };
+    // Filter cached insights to only domains the current isPremium gate
+    // allows. Without this guard, a downgrade (premium → free) would let
+    // previously-cached premium-domain text leak back through job.insights
+    // and the /insights/status/:jobId response.
+    const allowedDomainIds = new Set(domains.map(d => d.id));
+    const allowedExistingInsights: Record<string, string> = {};
+    for (const [domainId, text] of Object.entries(existingInsights)) {
+      if (allowedDomainIds.has(domainId)) {
+        allowedExistingInsights[domainId] = text;
+      }
+    }
+
+    // Initialize insights with allowed-only existing ones so we don't
+    // regenerate them and don't reintroduce disallowed domains.
+    const insights: Record<string, string> = { ...allowedExistingInsights };
     const domainsToProcess = domains.filter(d => !insights[d.id]);
     
     // Optimization: Prefetch detailed answers for ALL domains if Premium

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -281,6 +281,188 @@ router.delete(
   },
 );
 
+// Shared: compute per-domain / per-practice maturity scores for a project.
+// Used by POST /:projectId/submit (writes score into response after persisting
+// status change) and GET /:projectId/results (recomputes on demand so the
+// report stays available even when the client's local store is empty).
+async function computeProjectResults(
+  projectId: string,
+  isPremium: boolean,
+  projectVersionId: string | null
+): Promise<{
+  domains: any[];
+  overall: {
+    overallMaturityScore: number;
+    totalQuestions: number;
+    overallPercentage: number;
+  };
+}> {
+  const answersResult = await pool.query(
+    `SELECT domain_id, practice_id, level, stream, question_index, value
+     FROM assessment_answers
+     WHERE project_id = $1`,
+    [projectId]
+  );
+
+  let questionsQuery = `
+    SELECT d.id as domain_id, d.title as domain_title, COALESCE(d.is_premium, false) as is_premium,
+           p.id as practice_id, p.title as practice_title,
+           aq.level, aq.stream, aq.question_index
+    FROM aima_domains d
+    JOIN aima_practices p ON d.id = p.domain_id
+    JOIN aima_questions aq ON p.id = aq.practice_id
+  `;
+
+  const whereConditions: string[] = [];
+  const queryParams: any[] = [];
+  let paramIndex = 1;
+
+  if (!isPremium) {
+    whereConditions.push(`COALESCE(d.is_premium, false) = false`);
+  }
+
+  if (projectVersionId) {
+    whereConditions.push(`(d.version_id IS NULL OR EXISTS (
+      SELECT 1 FROM versions v1 WHERE v1.id = d.version_id
+      AND v1.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
+    ))`);
+    queryParams.push(projectVersionId);
+    paramIndex++;
+
+    whereConditions.push(`(p.version_id IS NULL OR EXISTS (
+      SELECT 1 FROM versions v2 WHERE v2.id = p.version_id
+      AND v2.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
+    ))`);
+    queryParams.push(projectVersionId);
+    paramIndex++;
+
+    whereConditions.push(`(aq.version_id IS NULL OR EXISTS (
+      SELECT 1 FROM versions v3 WHERE v3.id = aq.version_id
+      AND v3.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
+    ))`);
+    queryParams.push(projectVersionId);
+    paramIndex++;
+  }
+
+  if (whereConditions.length > 0) {
+    questionsQuery += ` WHERE ${whereConditions.join(" AND ")}`;
+  }
+
+  const questionsResult = await pool.query(questionsQuery, queryParams);
+
+  const structure = new Map<string, any>();
+
+  questionsResult.rows.forEach(row => {
+    if (!structure.has(row.domain_id)) {
+      structure.set(row.domain_id, {
+        title: row.domain_title,
+        isPremium: row.is_premium,
+        practices: new Map()
+      });
+    }
+    const domain = structure.get(row.domain_id);
+    if (!domain.practices.has(row.practice_id)) {
+      domain.practices.set(row.practice_id, {
+        title: row.practice_title,
+        totalQuestions: 0,
+        levels: {},
+        validQuestionKeys: new Set()
+      });
+    }
+    const practice = domain.practices.get(row.practice_id);
+    const questionKey = `${row.level}:${row.stream}:${row.question_index}`;
+    if (!practice.validQuestionKeys.has(questionKey)) {
+      practice.validQuestionKeys.add(questionKey);
+
+      if (!practice.levels[row.level]) practice.levels[row.level] = {};
+      if (!practice.levels[row.level][row.stream]) practice.levels[row.level][row.stream] = { total: 0, count: 0 };
+
+      practice.levels[row.level][row.stream].count++;
+      practice.totalQuestions++;
+    }
+  });
+
+  let totalQuestions = 0;
+  answersResult.rows.forEach(answer => {
+    const domain = structure.get(answer.domain_id);
+    if (domain) {
+      const practice = domain.practices.get(answer.practice_id);
+      const questionKey = `${answer.level}:${answer.stream}:${answer.question_index}`;
+      if (practice && practice.validQuestionKeys.has(questionKey)) {
+        practice.levels[answer.level][answer.stream].total += parseFloat(answer.value);
+      }
+    }
+  });
+
+  const domains = (Array.from(structure.entries()) as [string, any][]).map(([domainId, domain]) => {
+    const practices = (Array.from(domain.practices.entries()) as [string, any][]).map(([practiceId, practice]) => {
+      let practiceMaturityScore = 0;
+      let levelsCount = 0;
+
+      if (practice.levels) {
+        for (const level of Object.values(practice.levels)) {
+          let levelScore = 0;
+          let streamCount = 0;
+          for (const stream of Object.values(level as Record<string, { total: number, count: number }>)) {
+            if (stream.count > 0) {
+              levelScore += (stream.total / stream.count);
+              streamCount++;
+            }
+          }
+          if (streamCount > 0) {
+            practiceMaturityScore += (levelScore / streamCount);
+            levelsCount++;
+          }
+        }
+      }
+
+      const finalPracticeScore = levelsCount > 0 ? practiceMaturityScore / levelsCount : 0;
+
+      return {
+        practiceId,
+        practiceTitle: practice.title,
+        maturityScore: Math.round(finalPracticeScore * 100) / 100,
+        totalQuestions: practice.totalQuestions
+      };
+    });
+
+    const domainScore = practices.length > 0
+      ? Math.round((practices.reduce((sum: number, p: any) => sum + p.maturityScore, 0) / practices.length) * 100) / 100
+      : 0;
+
+    const domainTotalQuestions = practices.reduce((sum: number, p: any) => sum + p.totalQuestions, 0);
+    if (!domain.isPremium) {
+      totalQuestions += domainTotalQuestions;
+    }
+
+    return {
+      domainId,
+      domainTitle: domain.title,
+      maturityScore: domainScore,
+      practiceScores: practices,
+      totalQuestions: domainTotalQuestions,
+      isPremium: domain.isPremium,
+      percentage: (domainScore / 3) * 100
+    };
+  });
+
+  const relevantDomains = domains.filter(d => isPremium || !d.isPremium);
+  const overallMaturityScore = relevantDomains.length > 0
+    ? Math.round((relevantDomains.reduce((sum: number, d: any) => sum + d.maturityScore, 0) / relevantDomains.length) * 100) / 100
+    : 0;
+
+  const overallPercentage = (overallMaturityScore / 3) * 100;
+
+  return {
+    domains,
+    overall: {
+      overallMaturityScore,
+      totalQuestions,
+      overallPercentage
+    }
+  };
+}
+
 // Submit project
 router.post(
   "/:projectId/submit",
@@ -294,176 +476,11 @@ router.post(
 
     const project = req.project as { id: string; status: string; version_id: string | null };
     const projectVersionId = project.version_id;
-
-    // Check if project brand/owner is premium
     const isPremium = isPremiumUser((req.project as any).owner_subscription);
 
-    // Get all assessment answers for this project
-    const answersResult = await pool.query(
-      `SELECT domain_id, practice_id, level, stream, question_index, value 
-       FROM assessment_answers 
-       WHERE project_id = $1`,
-      [projectId]
-    );
+    const { domains, overall } = await computeProjectResults(projectId, isPremium, projectVersionId);
 
-    // Get total questions for each domain and practice
-    let questionsQuery = `
-      SELECT d.id as domain_id, d.title as domain_title, COALESCE(d.is_premium, false) as is_premium,
-             p.id as practice_id, p.title as practice_title,
-             aq.level, aq.stream, aq.question_index
-      FROM aima_domains d
-      JOIN aima_practices p ON d.id = p.domain_id
-      JOIN aima_questions aq ON p.id = aq.practice_id
-    `;
-    
-    const whereConditions: string[] = [];
-    const queryParams: any[] = [];
-    let paramIndex = 1;
-    
-    if (!isPremium) {
-      whereConditions.push(`COALESCE(d.is_premium, false) = false`);
-    }
-    
-    if (projectVersionId) {
-      whereConditions.push(`(d.version_id IS NULL OR EXISTS (
-        SELECT 1 FROM versions v1 WHERE v1.id = d.version_id 
-        AND v1.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
-      ))`);
-      queryParams.push(projectVersionId);
-      paramIndex++;
-      
-      whereConditions.push(`(p.version_id IS NULL OR EXISTS (
-        SELECT 1 FROM versions v2 WHERE v2.id = p.version_id 
-        AND v2.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
-      ))`);
-      queryParams.push(projectVersionId);
-      paramIndex++;
-      
-      whereConditions.push(`(aq.version_id IS NULL OR EXISTS (
-        SELECT 1 FROM versions v3 WHERE v3.id = aq.version_id 
-        AND v3.created_at <= (SELECT created_at FROM versions WHERE id = $${paramIndex})
-      ))`);
-      queryParams.push(projectVersionId);
-      paramIndex++;
-    }
-    
-    if (whereConditions.length > 0) {
-      questionsQuery += ` WHERE ${whereConditions.join(" AND ")}`;
-    }
-    
-    // No GROUP BY needed here as we want individual questions
-    
-    const questionsResult = await pool.query(questionsQuery, queryParams);
-
-    // Organize structure for scoring
-    const structure = new Map(); // domainId -> { title, isPremium, practices: Map(practiceId -> { title, totalQuestions, levels, validQuestionKeys }) }
-    
-    questionsResult.rows.forEach(row => {
-      if (!structure.has(row.domain_id)) {
-        structure.set(row.domain_id, {
-          title: row.domain_title,
-          isPremium: row.is_premium,
-          practices: new Map()
-        });
-      }
-      const domain = structure.get(row.domain_id);
-      if (!domain.practices.has(row.practice_id)) {
-        domain.practices.set(row.practice_id, {
-          title: row.practice_title,
-          totalQuestions: 0,
-          levels: {},
-          validQuestionKeys: new Set()
-        });
-      }
-      const practice = domain.practices.get(row.practice_id);
-      const questionKey = `${row.level}:${row.stream}:${row.question_index}`;
-      if (!practice.validQuestionKeys.has(questionKey)) {
-        practice.validQuestionKeys.add(questionKey);
-        
-        if (!practice.levels[row.level]) practice.levels[row.level] = {};
-        if (!practice.levels[row.level][row.stream]) practice.levels[row.level][row.stream] = { total: 0, count: 0 };
-        
-        practice.levels[row.level][row.stream].count++;
-        practice.totalQuestions++;
-      }
-    });
-
-    // Populate scores from answers
-    let totalQuestions = 0;
-    answersResult.rows.forEach(answer => {
-      const domain = structure.get(answer.domain_id);
-      if (domain) {
-        const practice = domain.practices.get(answer.practice_id);
-        const questionKey = `${answer.level}:${answer.stream}:${answer.question_index}`;
-        if (practice && practice.validQuestionKeys.has(questionKey)) {
-          practice.levels[answer.level][answer.stream].total += parseFloat(answer.value);
-        }
-      }
-    });
-
-    // Calculate Maturity Scores
-    const domains = (Array.from(structure.entries()) as [string, any][]).map(([domainId, domain]) => {
-      const practices = (Array.from(domain.practices.entries()) as [string, any][]).map(([practiceId, practice]) => {
-        let practiceMaturityScore = 0;
-        let levelsCount = 0;
-        
-        if (practice.levels) {
-          for (const level of Object.values(practice.levels)) {
-            let levelScore = 0;
-            let streamCount = 0;
-            for (const stream of Object.values(level as Record<string, { total: number, count: number }>)) {
-              if (stream.count > 0) {
-                levelScore += (stream.total / stream.count);
-                streamCount++;
-              }
-            }
-            if (streamCount > 0) {
-              practiceMaturityScore += (levelScore / streamCount);
-              levelsCount++;
-            }
-          }
-        }
-        
-        // Compute average across levels before rounding
-        const finalPracticeScore = levelsCount > 0 ? practiceMaturityScore / levelsCount : 0;
-        
-        return {
-          practiceId,
-          practiceTitle: practice.title,
-          maturityScore: Math.round(finalPracticeScore * 100) / 100,
-          totalQuestions: practice.totalQuestions
-        };
-      });
-
-      const domainScore = practices.length > 0
-        ? Math.round((practices.reduce((sum: number, p: any) => sum + p.maturityScore, 0) / practices.length) * 100) / 100
-        : 0;
-      
-      const domainTotalQuestions = practices.reduce((sum: number, p: any) => sum + p.totalQuestions, 0);
-      if (!domain.isPremium) {
-        totalQuestions += domainTotalQuestions;
-      }
-
-      return {
-        domainId,
-        domainTitle: domain.title,
-        maturityScore: domainScore,
-        practiceScores: practices,
-        totalQuestions: domainTotalQuestions,
-        isPremium: domain.isPremium,
-        // Legacy percentage field for compatibility during transition if needed
-        percentage: (domainScore / 3) * 100 
-      };
-    });
-
-    const relevantDomains = domains.filter(d => isPremium || !d.isPremium);
-    const overallMaturityScore = relevantDomains.length > 0
-      ? Math.round((relevantDomains.reduce((sum: number, d: any) => sum + d.maturityScore, 0) / relevantDomains.length) * 100) / 100
-      : 0;
-
-    const overallPercentage = (overallMaturityScore / 3) * 100;
-
-    // Update project status to completed
+    // New submission invalidates any previously-cached AI insights.
     await pool.query(
       "DELETE FROM project_insights WHERE project_id = $1",
       [projectId]
@@ -481,29 +498,71 @@ router.post(
       objectType: "PROJECT",
       objectId: projectId,
       metadata: {
-        overallMaturityScore,
-        totalQuestions,
-        overallPercentage,
+        overallMaturityScore: overall.overallMaturityScore,
+        totalQuestions: overall.totalQuestions,
+        overallPercentage: overall.overallPercentage,
       },
     });
 
     res.json({
       message: "Project submitted successfully",
       project: result.rows[0],
-      results: {
-        domains,
-        overall: {
-          overallMaturityScore,
-          totalQuestions,
-          overallPercentage
-        }
-      }
+      results: { domains, overall }
     });
   } catch (error) {
     console.error("Error submitting project:", error);
     res.status(500).json({ error: "Failed to submit project" });
   }
 });
+
+// Fetch computed report for a submitted project. Makes the score-report URL
+// load for any authorized viewer (not just the browser session that submitted).
+router.get(
+  "/:projectId/results",
+  authenticateToken,
+  loadProject,
+  requireProjectRole(["OWNER", "EDITOR", "VIEWER"]),
+  async (req, res) => {
+    try {
+      const { projectId } = req.params;
+      const project = req.project as { id: string; name: string; status: string; version_id: string | null };
+      const isPremium = isPremiumUser((req.project as any).owner_subscription);
+
+      const { domains, overall } = await computeProjectResults(
+        projectId,
+        isPremium,
+        project.version_id
+      );
+
+      const insightsResult = await pool.query(
+        "SELECT domain_id, insight_text FROM project_insights WHERE project_id = $1",
+        [projectId]
+      );
+      const insights: Record<string, string> = {};
+      insightsResult.rows.forEach(row => {
+        insights[row.domain_id] = row.insight_text;
+      });
+
+      const submittedRow = await pool.query(
+        "SELECT updated_at FROM projects WHERE id = $1",
+        [projectId]
+      );
+      const submittedAt = project.status === 'completed' && submittedRow.rows[0]?.updated_at
+        ? new Date(submittedRow.rows[0].updated_at).toISOString()
+        : null;
+
+      res.json({
+        project,
+        results: { domains, overall },
+        insights,
+        submittedAt,
+      });
+    } catch (error) {
+      console.error("Error fetching project results:", error);
+      res.status(500).json({ error: "Failed to fetch project results" });
+    }
+  }
+);
 
 // --- Project invitations ---
 
@@ -1017,20 +1076,28 @@ const generateInsightsAsync = async (
             detailedContext = detailedContextMap.get(domain.id) || "";
         }
 
-        const prompt = `You are an AI assessment expert analyzing domain maturity based on the OWASP AIMA model. Generate actionable insights and recommendations for the following domain:
- 
- Domain: ${domain.title}
- Description: ${domain.description || 'N/A'}
- Maturity Score: ${maturityScore.toFixed(2)} / 3.0
- Project: ${projectName}${detailedContext}
- 
- Based on this maturity scoring${isPremium ? ' and the detailed question analysis above' : ''}, provide:
- 1. A brief analysis of the current maturity level
- 2. Key strengths (if any)
- 3. Areas that need improvement
- 4. Specific actionable recommendations${isPremium ? ' based on the specific question scores' : ''}
- 
- Keep the response concise (2-3 paragraphs) and focused on practical next steps. Format as plain text without markdown.`;
+        // Sections must be parseable by the frontend (see insightUtils.parseInsightText).
+        // Headings and the numbered RECOMMENDATIONS list are the contract — do not reword.
+        const prompt = `You are an AI assessment expert analyzing domain maturity based on the OWASP AIMA model.
+
+Domain: ${domain.title}
+Description: ${domain.description || 'N/A'}
+Maturity Score: ${maturityScore.toFixed(2)} / 3.0
+Project: ${projectName}${detailedContext}
+
+Produce the response in exactly FOUR sections using these EXACT headings, each on its own line, in this order. Do not use markdown, bold, or any other formatting — plain text only.
+
+ANALYSIS:
+A single paragraph (3-5 sentences) summarizing the current maturity level${isPremium ? ' and what the detailed question scores reveal' : ''}.
+
+STRENGTHS:
+A short paragraph listing current strengths. If there are none at this maturity level, write exactly: "None identified at this maturity level."
+
+AREAS FOR IMPROVEMENT:
+A short paragraph naming the most important gaps${isPremium ? ' based on the specific question scores' : ''}.
+
+RECOMMENDATIONS:
+Exactly 3 to 5 concrete, actionable recommendations as a numbered list, each on its own line. Use the format "1. <action>", "2. <action>", etc. Each recommendation must be an imperative sentence the team can act on (e.g., "Draft a high-level AI policy statement covering ethical principles and compliance requirements."). Do not restate analysis here — only actions. This section must never be empty; if the domain is at score 0, still produce foundational Level-0-to-Level-1 actions (e.g., forming a working group, drafting initial policies, running an initial risk workshop).`;
 
         let lastError: any = null;
         let insightText = "";

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -490,7 +490,9 @@ router.post(
     );
 
     const result = await pool.query(
-      "UPDATE projects SET status = 'completed', updated_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING *",
+      // submitted_at is set on the first submission only; resubmits and later
+      // metadata edits must not shift it (updated_at moves freely instead).
+      "UPDATE projects SET status = 'completed', submitted_at = COALESCE(submitted_at, CURRENT_TIMESTAMP), updated_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING *",
       [projectId],
     );
 
@@ -510,7 +512,10 @@ router.post(
     res.json({
       message: "Project submitted successfully",
       project: result.rows[0],
-      results: { domains, overall }
+      results: { domains, overall },
+      capabilities: {
+        premiumInsights: isPremium,
+      },
     });
   } catch (error) {
     console.error("Error submitting project:", error);
@@ -546,17 +551,24 @@ router.get(
         "SELECT domain_id, insight_text FROM project_insights WHERE project_id = $1",
         [projectId]
       );
+      // Only surface insights for domains the viewer is actually allowed to
+      // see (computeProjectResults already filtered out premium domains for
+      // non-premium projects). Without this guard, stale cache rows from a
+      // prior premium state could leak premium-domain text.
+      const allowedDomainIds = new Set(domains.map((d: any) => d.domainId));
       const insights: Record<string, string> = {};
       insightsResult.rows.forEach(row => {
-        insights[row.domain_id] = row.insight_text;
+        if (allowedDomainIds.has(row.domain_id)) {
+          insights[row.domain_id] = row.insight_text;
+        }
       });
 
       const submittedRow = await pool.query(
-        "SELECT updated_at FROM projects WHERE id = $1",
+        "SELECT submitted_at FROM projects WHERE id = $1",
         [projectId]
       );
-      const submittedAt = submittedRow.rows[0]?.updated_at
-        ? new Date(submittedRow.rows[0].updated_at).toISOString()
+      const submittedAt = submittedRow.rows[0]?.submitted_at
+        ? new Date(submittedRow.rows[0].submitted_at).toISOString()
         : null;
 
       res.json({
@@ -564,6 +576,12 @@ router.get(
         results: { domains, overall },
         insights,
         submittedAt,
+        // Project-level capability so the UI can gate premium insights by the
+        // project/owner's plan rather than the viewer's plan — free
+        // collaborators on a premium owner's project still get full insights.
+        capabilities: {
+          premiumInsights: isPremium,
+        },
       });
     } catch (error) {
       console.error("Error fetching project results:", error);

--- a/backend/src/schema/schema.sql
+++ b/backend/src/schema/schema.sql
@@ -23,8 +23,15 @@ CREATE TABLE IF NOT EXISTS projects (
   ai_system_type VARCHAR(255),
   status VARCHAR(50) DEFAULT 'not_started' CHECK (status IN ('not_started', 'in_progress', 'completed')),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  -- Stamped on the first successful submission only; nullable so unsubmitted
+  -- projects stay NULL. Mirrors migration 1774900000000_add-submitted-at-to-projects.
+  submitted_at TIMESTAMP
 );
+
+-- Older DBs created before submitted_at existed get the column added here too.
+ALTER TABLE projects
+ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMP;
 
 -- Assessment answers table
 CREATE TABLE IF NOT EXISTS assessment_answers (

--- a/backend/src/schema/schema.sql
+++ b/backend/src/schema/schema.sql
@@ -33,6 +33,13 @@ CREATE TABLE IF NOT EXISTS projects (
 ALTER TABLE projects
 ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMP;
 
+-- Match the backfill in migration 1774900000000_add-submitted-at-to-projects:
+-- existing completed projects use updated_at as their best available
+-- submission timestamp so historical reports keep rendering a date.
+UPDATE projects
+SET submitted_at = updated_at
+WHERE status = 'completed' AND submitted_at IS NULL;
+
 -- Assessment answers table
 CREATE TABLE IF NOT EXISTS assessment_answers (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/frontend/src/app/score-report-aima/page.tsx
+++ b/frontend/src/app/score-report-aima/page.tsx
@@ -59,13 +59,35 @@ export default function ScoreReportPage() {
     }
 
     const fetchData = async () => {
-      // 1. Get Results
-      const projectResults = getProjectResults(projectId);
+      // Prefer the local cache (fast path, typical after submit). Fall back to
+      // the server when the browser has no entry — handles refresh after
+      // localStorage clear, another browser, another device, or a shared link.
+      let projectResults = getProjectResults(projectId) as any;
+
+      if (!projectResults) {
+        try {
+          const report = await apiService.getProjectReport(projectId);
+          if (report?.results?.domains?.length) {
+            const domainsWithInsights = report.results.domains.map((d: any) => ({
+              ...d,
+              insights: report.insights?.[d.domainId] || d.insights,
+            }));
+            projectResults = {
+              projectId,
+              project: report.project,
+              results: { ...report.results, domains: domainsWithInsights },
+              submittedAt: report.submittedAt ?? new Date().toISOString(),
+            };
+          }
+        } catch (err) {
+          console.error("Failed to fetch project report from server:", err);
+        }
+      }
+
       if (projectResults) {
         setResults(projectResults);
       }
 
-      // 2. Get Domain Details to check for premium status
       try {
         const domainsData = await apiService.getDomainsFull(projectId);
         const premiumIds = new Set(
@@ -259,16 +281,23 @@ export default function ScoreReportPage() {
 
             <Button
               onClick={exportVectorPdf}
-              disabled={isExporting}
+              disabled={isExporting || generatingInsights}
               size="sm"
-              className="group flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20"
+              title={generatingInsights ? "Insights are still being generated — please wait" : undefined}
+              className="group flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
             >
-              {isExporting ? (
+              {isExporting || generatingInsights ? (
                 <IconLoader className="w-4 h-4 animate-spin" />
               ) : (
                 <IconDownload className="w-4 h-4" />
               )}
-              <span className="font-medium text-xs">{isExporting ? "Generating..." : "Download Report"}</span>
+              <span className="font-medium text-xs">
+                {isExporting
+                  ? "Generating..."
+                  : generatingInsights
+                  ? "Preparing insights..."
+                  : "Download Report"}
+              </span>
             </Button>
           </div>
 

--- a/frontend/src/app/score-report-aima/page.tsx
+++ b/frontend/src/app/score-report-aima/page.tsx
@@ -154,6 +154,10 @@ export default function ScoreReportPage() {
         }
 
         if (response.success && response.jobId && (response.status === 'processing' || response.status === 'pending')) {
+          if (response.existingInsights && Object.keys(response.existingInsights).length > 0) {
+            setInsights(prev => ({ ...prev, ...response.existingInsights }));
+            updateResultsWithInsights(response.existingInsights);
+          }
           pullInsightsStatus(response.jobId);
 
           safetyTimeout = setTimeout(() => {

--- a/frontend/src/app/score-report-aima/page.tsx
+++ b/frontend/src/app/score-report-aima/page.tsx
@@ -178,7 +178,6 @@ export default function ScoreReportPage() {
         if (response.success && response.jobId && (response.status === 'processing' || response.status === 'pending')) {
           if (response.existingInsights && Object.keys(response.existingInsights).length > 0) {
             setInsights(prev => ({ ...prev, ...response.existingInsights }));
-            updateResultsWithInsights(response.existingInsights);
           }
           pullInsightsStatus(response.jobId);
 

--- a/frontend/src/app/score-report-aima/page.tsx
+++ b/frontend/src/app/score-report-aima/page.tsx
@@ -64,7 +64,12 @@ export default function ScoreReportPage() {
       // localStorage clear, another browser, another device, or a shared link.
       let projectResults = getProjectResults(projectId) as any;
 
-      if (!projectResults) {
+      // Refresh when the cache predates the capability flags so VIEWERs
+      // don't auto-trigger a /generate-insights request that will 403.
+      const cacheNeedsCapabilityRefresh =
+        !!projectResults && projectResults.capabilities?.canGenerateInsights === undefined;
+
+      if (!projectResults || cacheNeedsCapabilityRefresh) {
         try {
           const report = await apiService.getProjectReport(projectId);
           if (report?.results?.domains?.length) {
@@ -77,6 +82,7 @@ export default function ScoreReportPage() {
               project: report.project,
               results: { ...report.results, domains: domainsWithInsights },
               submittedAt: report.submittedAt ?? null,
+              capabilities: report.capabilities,
             };
           }
         } catch (err) {
@@ -157,6 +163,11 @@ export default function ScoreReportPage() {
     const generateInsights = async () => {
       // Guard: Ensure premium domains are resolved and no error
       if (premiumDomainIds === null || premiumDomainError) return;
+
+      // VIEWERs can't trigger generation server-side; default true preserves
+      // behavior for cached entries that predate the capability field.
+      const canGenerateInsights = results?.capabilities?.canGenerateInsights ?? true;
+      if (!canGenerateInsights) return;
 
       // Check if we already have insights for all relevant domains
       const nonPremiumDomainsToCheck = results.results.domains.filter((d: any) => !premiumDomainIds?.has(d.domainId));

--- a/frontend/src/app/score-report-aima/page.tsx
+++ b/frontend/src/app/score-report-aima/page.tsx
@@ -76,7 +76,7 @@ export default function ScoreReportPage() {
               projectId,
               project: report.project,
               results: { ...report.results, domains: domainsWithInsights },
-              submittedAt: report.submittedAt ?? new Date().toISOString(),
+              submittedAt: report.submittedAt ?? null,
             };
           }
         } catch (err) {
@@ -321,7 +321,9 @@ export default function ScoreReportPage() {
                 <div className="flex flex-col">
                   <span className="text-[9px] font-black uppercase tracking-[0.2em] text-muted-foreground mb-0.5">Assessment Date</span>
                   <span className="text-base font-bold text-foreground">
-                    {new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                    {results.submittedAt
+                      ? new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+                      : "Submission date unavailable"}
                   </span>
                 </div>
               </div>

--- a/frontend/src/app/score-report-premium/page.tsx
+++ b/frontend/src/app/score-report-premium/page.tsx
@@ -61,12 +61,32 @@ export default function ScoreReportPage() {
     }
 
     const fetchData = async () => {
-      const projectResults = getProjectResults(projectId);
+      // Prefer the local cache; fall back to server so the report remains
+      // available across browsers, devices, and after localStorage clears.
+      let projectResults = getProjectResults(projectId) as any;
+
+      if (!projectResults) {
+        try {
+          const report = await apiService.getProjectReport(projectId);
+          if (report?.results?.domains?.length) {
+            const domainsWithInsights = report.results.domains.map((d: any) => ({
+              ...d,
+              insights: report.insights?.[d.domainId] || d.insights,
+            }));
+            projectResults = {
+              projectId,
+              project: report.project,
+              results: { ...report.results, domains: domainsWithInsights },
+              submittedAt: report.submittedAt ?? new Date().toISOString(),
+            };
+          }
+        } catch (err) {
+          console.error("Failed to fetch project report from server:", err);
+        }
+      }
+
       if (projectResults) {
         setResults(projectResults);
-      } else if (projectId) {
-        // Handle case where we have a projectId but no results yet
-        // This might happen if user bookmarked or manually navigated
       }
 
       try {
@@ -237,15 +257,22 @@ export default function ScoreReportPage() {
 
             <Button
               onClick={exportPdf}
-              disabled={isExporting}
-              className="group flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hide-in-pdf px-6 py-2 rounded-xl"
+              disabled={isExporting || generatingInsights}
+              title={generatingInsights ? "Insights are still being generated — please wait" : undefined}
+              className="group flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/20 hide-in-pdf px-6 py-2 rounded-xl disabled:opacity-60 disabled:cursor-not-allowed"
             >
-              {isExporting ? (
+              {isExporting || generatingInsights ? (
                 <IconLoader className="w-5 h-5 animate-spin" />
               ) : (
                 <IconDownload className="w-5 h-5" />
               )}
-              <span className="font-medium">{isExporting ? "Generating PDF..." : "Download Report"}</span>
+              <span className="font-medium">
+                {isExporting
+                  ? "Generating PDF..."
+                  : generatingInsights
+                  ? "Preparing insights..."
+                  : "Download Report"}
+              </span>
             </Button>
           </div>
 

--- a/frontend/src/app/score-report-premium/page.tsx
+++ b/frontend/src/app/score-report-premium/page.tsx
@@ -37,6 +37,9 @@ export default function ScoreReportPage() {
   const { getProjectResults } = useAssessmentResultsStore();
   const reportRef = useRef<HTMLDivElement>(null);
 
+  // Fallback only — premium-insight visibility is now driven by the
+  // project/report capability flag (see hasPremiumInsights below) so that
+  // free collaborators on a premium owner's project still get full insights.
   const isUserPremium = user?.subscription_status === "basic_premium" || user?.subscription_status === "pro_premium";
 
   const projectId = searchParams.get("projectId");
@@ -78,6 +81,7 @@ export default function ScoreReportPage() {
               project: report.project,
               results: { ...report.results, domains: domainsWithInsights },
               submittedAt: report.submittedAt ?? new Date().toISOString(),
+              capabilities: report.capabilities,
             };
           }
         } catch (err) {
@@ -107,8 +111,12 @@ export default function ScoreReportPage() {
     fetchData();
   }, [projectId, isAuthenticated, authLoading, getProjectResults]);
 
+  // Project/report-level capability — falls back to the viewer's plan only
+  // when the cached results predate the capability field.
+  const hasPremiumInsights = results?.capabilities?.premiumInsights ?? isUserPremium;
+
   useEffect(() => {
-    if (!projectId || !results || loading || !isUserPremium) return;
+    if (!projectId || !results || loading || !hasPremiumInsights) return;
 
     // Collect all existing insights from results
     const existingInsights: Record<string, string> = {};
@@ -205,7 +213,7 @@ export default function ScoreReportPage() {
       isPolling = false;
       if (safetyTimeout) clearTimeout(safetyTimeout);
     };
-  }, [projectId, results, loading, isUserPremium]);
+  }, [projectId, results, loading, hasPremiumInsights]);
 
   if (loading) {
     return <ReportSkeleton />;
@@ -425,7 +433,7 @@ export default function ScoreReportPage() {
           <div className="space-y-12">
             {results.results.domains.map((domain: any, index: number) => {
               const domainMaturity = getMaturityLevel(domain.maturityScore);
-              const domainInsights = parseInsightText(insights[domain.domainId] || (isUserPremium ? domain.insights : "") || "");
+              const domainInsights = parseInsightText(insights[domain.domainId] || (hasPremiumInsights ? domain.insights : "") || "");
 
               return (
                 <motion.div

--- a/frontend/src/app/score-report-premium/page.tsx
+++ b/frontend/src/app/score-report-premium/page.tsx
@@ -68,7 +68,14 @@ export default function ScoreReportPage() {
       // available across browsers, devices, and after localStorage clears.
       let projectResults = getProjectResults(projectId) as any;
 
-      if (!projectResults) {
+      // Refresh from the server when the cache predates the capability flag
+      // (legacy entries) — without this, hasPremiumInsights silently falls
+      // back to the viewer's plan and free collaborators on a premium project
+      // see the same blanked insights as before.
+      const cacheNeedsCapabilityRefresh =
+        !!projectResults && projectResults.capabilities?.premiumInsights === undefined;
+
+      if (!projectResults || cacheNeedsCapabilityRefresh) {
         try {
           const report = await apiService.getProjectReport(projectId);
           if (report?.results?.domains?.length) {
@@ -80,7 +87,9 @@ export default function ScoreReportPage() {
               projectId,
               project: report.project,
               results: { ...report.results, domains: domainsWithInsights },
-              submittedAt: report.submittedAt ?? new Date().toISOString(),
+              // Preserve a missing submission timestamp instead of inventing
+              // one — consumers render a fallback label when null.
+              submittedAt: report.submittedAt ?? null,
               capabilities: report.capabilities,
             };
           }
@@ -114,9 +123,13 @@ export default function ScoreReportPage() {
   // Project/report-level capability — falls back to the viewer's plan only
   // when the cached results predate the capability field.
   const hasPremiumInsights = results?.capabilities?.premiumInsights ?? isUserPremium;
+  // VIEWERs can read but not generate; the /generate-insights route would
+  // 403 them. Default true so cached entries that predate the flag continue
+  // to work for OWNER/EDITOR sessions (same role that produced the cache).
+  const canGenerateInsights = results?.capabilities?.canGenerateInsights ?? true;
 
   useEffect(() => {
-    if (!projectId || !results || loading || !hasPremiumInsights) return;
+    if (!projectId || !results || loading || !hasPremiumInsights || !canGenerateInsights) return;
 
     // Collect all existing insights from results
     const existingInsights: Record<string, string> = {};
@@ -213,7 +226,7 @@ export default function ScoreReportPage() {
       isPolling = false;
       if (safetyTimeout) clearTimeout(safetyTimeout);
     };
-  }, [projectId, results, loading, hasPremiumInsights]);
+  }, [projectId, results, loading, hasPremiumInsights, canGenerateInsights]);
 
   if (loading) {
     return <ReportSkeleton />;
@@ -296,7 +309,9 @@ export default function ScoreReportPage() {
                 <span className="font-semibold text-foreground">{results.project.name}</span>
                 <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
                 <span className="text-muted-foreground">
-                    {new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                    {results.submittedAt
+                      ? new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+                      : "Submission date unavailable"}
                 </span>
               </div>
             </div>

--- a/frontend/src/app/score-report-premium/page.tsx
+++ b/frontend/src/app/score-report-premium/page.tsx
@@ -170,7 +170,6 @@ export default function ScoreReportPage() {
         if (response.success && response.jobId && response.status === 'processing') {
           if (response.existingInsights && Object.keys(response.existingInsights).length > 0) {
             setInsights(prev => ({ ...prev, ...response.existingInsights }));
-            updateResultsWithInsights(response.existingInsights);
           }
           pullInsightsStatus(response.jobId);
 

--- a/frontend/src/app/score-report-premium/page.tsx
+++ b/frontend/src/app/score-report-premium/page.tsx
@@ -148,6 +148,10 @@ export default function ScoreReportPage() {
         }
 
         if (response.success && response.jobId && response.status === 'processing') {
+          if (response.existingInsights && Object.keys(response.existingInsights).length > 0) {
+            setInsights(prev => ({ ...prev, ...response.existingInsights }));
+            updateResultsWithInsights(response.existingInsights);
+          }
           pullInsightsStatus(response.jobId);
 
           safetyTimeout = setTimeout(() => {

--- a/frontend/src/contexts/AssessmentContext.tsx
+++ b/frontend/src/contexts/AssessmentContext.tsx
@@ -670,7 +670,7 @@ export const AssessmentProvider = ({ children }: { children: React.ReactNode }) 
 
             const response = await apiService.submitProject(projectId);
 
-            setProjectResults(projectId, response.project, response.results);
+            setProjectResults(projectId, response.project, response.results, response.capabilities);
             router.push(`/score-report-aima?projectId=${projectId}`);
         } catch (error) {
             console.error("Failed to submit project:", error);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1106,6 +1106,7 @@ class ApiService {
   async generateDomainInsights(projectId: string): Promise<{
     success: boolean;
     insights?: Record<string, string>; // domainId -> insights text
+    existingInsights?: Record<string, string>; // cached insights when a new job is kicked off
     jobId?: string;
     status?: InsightsJobStatus;
     message?: string;
@@ -1114,6 +1115,7 @@ class ApiService {
     return this.request<{
       success: boolean;
       insights?: Record<string, string>;
+      existingInsights?: Record<string, string>;
       jobId?: string;
       status?: InsightsJobStatus;
       message?: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1125,6 +1125,36 @@ class ApiService {
     });
   }
 
+  async getProjectReport(projectId: string): Promise<{
+    project: any;
+    results: {
+      domains: Array<{
+        domainId: string;
+        domainTitle: string;
+        maturityScore: number;
+        practiceScores: Array<{
+          practiceId: string;
+          practiceTitle: string;
+          maturityScore: number;
+          totalQuestions: number;
+        }>;
+        totalQuestions: number;
+        isPremium?: boolean;
+        percentage: number;
+        insights?: string;
+      }>;
+      overall: {
+        overallMaturityScore: number;
+        totalQuestions: number;
+        overallPercentage: number;
+      };
+    };
+    insights: Record<string, string>;
+    submittedAt: string | null;
+  }> {
+    return this.request(`/projects/${projectId}/results`);
+  }
+
   async getInsightsJobStatus(projectId: string, jobId: string): Promise<{
     jobId: string;
     status: InsightsJobStatus;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -343,8 +343,8 @@ class ApiService {
     });
   }
 
-  async submitProject(id: string): Promise<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean } }> {
-    return this.request<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean } }>(`/projects/${id}/submit`, {
+  async submitProject(id: string): Promise<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean; canGenerateInsights?: boolean } }> {
+    return this.request<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean; canGenerateInsights?: boolean } }>(`/projects/${id}/submit`, {
       method: "POST",
     });
   }
@@ -1153,6 +1153,7 @@ class ApiService {
     submittedAt: string | null;
     capabilities?: {
       premiumInsights?: boolean;
+      canGenerateInsights?: boolean;
     };
   }> {
     return this.request(`/projects/${projectId}/results`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -343,8 +343,8 @@ class ApiService {
     });
   }
 
-  async submitProject(id: string): Promise<{ message: string; project: Project; results: any }> {
-    return this.request<{ message: string; project: Project; results: any }>(`/projects/${id}/submit`, {
+  async submitProject(id: string): Promise<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean } }> {
+    return this.request<{ message: string; project: Project; results: any; capabilities?: { premiumInsights?: boolean } }>(`/projects/${id}/submit`, {
       method: "POST",
     });
   }
@@ -1151,6 +1151,9 @@ class ApiService {
     };
     insights: Record<string, string>;
     submittedAt: string | null;
+    capabilities?: {
+      premiumInsights?: boolean;
+    };
   }> {
     return this.request(`/projects/${projectId}/results`);
   }

--- a/frontend/src/lib/pdfExport/AimaPdfDocument.tsx
+++ b/frontend/src/lib/pdfExport/AimaPdfDocument.tsx
@@ -396,7 +396,9 @@ export const AimaPdfDocument: React.FC<AimaPdfDocumentProps> = ({ results, nonPr
             <View style={styles.metaItem}>
               <Text style={styles.metaLabel}>Assessment Date</Text>
               <Text style={styles.metaValue}>
-                {new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                {results.submittedAt
+                  ? new Date(results.submittedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+                  : "Submission date unavailable"}
               </Text>
             </View>
           </View>

--- a/frontend/src/store/assessmentResultsStore.ts
+++ b/frontend/src/store/assessmentResultsStore.ts
@@ -78,18 +78,19 @@ export const useAssessmentResultsStore = create<AssessmentResultsStore>()(
           // Prefer the server's persisted submission timestamp (carried on the
           // project row as submitted_at, or on the results payload if a caller
           // attached one). Fall back to whatever was already cached so we
-          // don't clobber a real timestamp with a fresh wall-clock value, and
-          // only synthesize Date.now() as a last resort when neither exists.
+          // don't clobber a real timestamp with a fresh wall-clock value.
+          // When no server-side timestamp is available anywhere, leave
+          // submittedAt null and let UI/PDF render a fallback label rather
+          // than inventing a misleading "submitted today" date.
           const incomingSubmittedAt =
             (results as any)?.submitted_at ??
             project?.submitted_at ??
             null;
           const existingSubmittedAt =
             existingIndex >= 0 ? state.projectResults[existingIndex].submittedAt : null;
-          const submittedAt: string | null =
-            incomingSubmittedAt
-              ? new Date(incomingSubmittedAt).toISOString()
-              : existingSubmittedAt ?? new Date().toISOString();
+          const submittedAt: string | null = incomingSubmittedAt
+            ? new Date(incomingSubmittedAt).toISOString()
+            : existingSubmittedAt ?? null;
 
           const newProjectResult: ProjectResult = {
             projectId,

--- a/frontend/src/store/assessmentResultsStore.ts
+++ b/frontend/src/store/assessmentResultsStore.ts
@@ -30,13 +30,14 @@ interface AssessmentResults {
 
 interface ProjectCapabilities {
   premiumInsights?: boolean;
+  canGenerateInsights?: boolean;
 }
 
 interface ProjectResult {
   projectId: string;
   project: any; // Project data from backend
   results: AssessmentResults;
-  submittedAt: string; // ISO timestamp
+  submittedAt: string | null; // ISO timestamp from the server; null until backfilled
   capabilities?: ProjectCapabilities;
 }
 
@@ -74,11 +75,27 @@ export const useAssessmentResultsStore = create<AssessmentResultsStore>()(
         set((state) => {
           const existingIndex = state.projectResults.findIndex(pr => pr.projectId === projectId);
 
+          // Prefer the server's persisted submission timestamp (carried on the
+          // project row as submitted_at, or on the results payload if a caller
+          // attached one). Fall back to whatever was already cached so we
+          // don't clobber a real timestamp with a fresh wall-clock value, and
+          // only synthesize Date.now() as a last resort when neither exists.
+          const incomingSubmittedAt =
+            (results as any)?.submitted_at ??
+            project?.submitted_at ??
+            null;
+          const existingSubmittedAt =
+            existingIndex >= 0 ? state.projectResults[existingIndex].submittedAt : null;
+          const submittedAt: string | null =
+            incomingSubmittedAt
+              ? new Date(incomingSubmittedAt).toISOString()
+              : existingSubmittedAt ?? new Date().toISOString();
+
           const newProjectResult: ProjectResult = {
             projectId,
             project,
             results,
-            submittedAt: new Date().toISOString(),
+            submittedAt,
             capabilities,
           };
           
@@ -123,9 +140,12 @@ export const useAssessmentResultsStore = create<AssessmentResultsStore>()(
         const state = get();
         if (state.projectResults.length === 0) return null;
         
-        // Sort by submittedAt descending and return the latest
+        // Sort by submittedAt descending and return the latest. Treat null
+        // timestamps as the epoch so they sort to the bottom rather than
+        // throwing on Date(null).
+        const tsOrZero = (v: string | null) => (v ? new Date(v).getTime() : 0);
         const sortedResults = [...state.projectResults].sort(
-          (a, b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
+          (a, b) => tsOrZero(b.submittedAt) - tsOrZero(a.submittedAt)
         );
         
         return sortedResults[0];

--- a/frontend/src/store/assessmentResultsStore.ts
+++ b/frontend/src/store/assessmentResultsStore.ts
@@ -28,18 +28,23 @@ interface AssessmentResults {
   overall: OverallResult;
 }
 
+interface ProjectCapabilities {
+  premiumInsights?: boolean;
+}
+
 interface ProjectResult {
   projectId: string;
   project: any; // Project data from backend
   results: AssessmentResults;
   submittedAt: string; // ISO timestamp
+  capabilities?: ProjectCapabilities;
 }
 
 interface AssessmentResultsStore {
   projectResults: ProjectResult[];
-  
+
   // Store assessment results for a project
-  setProjectResults: (projectId: string, project: any, results: AssessmentResults) => void;
+  setProjectResults: (projectId: string, project: any, results: AssessmentResults, capabilities?: ProjectCapabilities) => void;
   
   // Get assessment results for a specific project
   getProjectResults: (projectId: string) => ProjectResult | null;
@@ -65,15 +70,16 @@ export const useAssessmentResultsStore = create<AssessmentResultsStore>()(
     (set, get) => ({
       projectResults: [],
       
-      setProjectResults: (projectId: string, project: any, results: AssessmentResults) => {
+      setProjectResults: (projectId: string, project: any, results: AssessmentResults, capabilities?: ProjectCapabilities) => {
         set((state) => {
           const existingIndex = state.projectResults.findIndex(pr => pr.projectId === projectId);
-          
+
           const newProjectResult: ProjectResult = {
             projectId,
             project,
             results,
             submittedAt: new Date().toISOString(),
+            capabilities,
           };
           
           if (existingIndex >= 0) {
@@ -134,4 +140,4 @@ export const useAssessmentResultsStore = create<AssessmentResultsStore>()(
 );
 
 // Export types for use in components
-export type { DomainResult, OverallResult, AssessmentResults, ProjectResult };
+export type { DomainResult, OverallResult, AssessmentResults, ProjectResult, ProjectCapabilities };


### PR DESCRIPTION
POST /generate-insights previously returned only {jobId, status: 'processing'} when any domain needed regeneration, causing the score-report UI to show the "Analyzing…" spinner on every domain — including ones whose insights were already cached. The response now also includes existingInsights (the cached rows from project_insights), and the score-report pages merge them into state before polling begins. Spinner now only shows on domains the new job is actually regenerating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand project results endpoint returns recomputed report with submittedAt, domain insights, and premium-insights/can-generate capabilities.
* **Improvements**
  * Submission response now includes consolidated overall metrics and project capabilities.
  * Insights generation can immediately return cached domain insights while deeper processing continues.
  * Insight output must follow a stricter four-section format with 3–5 numbered recommendations.
* **UX**
  * Report download/export is disabled and shows “Preparing insights…” while insights are generating.
* **Bug Fixes**
  * Submission date handling now shows “Submission date unavailable” when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->