### PR TITLE
feat: add overwrite duplicate controls option in bulk import

### DIFF
--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -422,11 +422,13 @@ router.post("/controls", authenticateToken, requireRole(["ADMIN"]), async (req, 
   }
 });
 
-// POST /crc/controls/bulk - Bulk create controls (all-or-nothing)
+// POST /crc/controls/bulk - Bulk create controls (all-or-nothing / upsert compatible)
 router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (req, res) => {
   const client = await pool.connect();
   try {
     const raw = req.body;
+    const overwrite = raw.overwrite === true;
+
     if (!Array.isArray(raw.controls)) {
       return res.status(400).json({ success: false, errors: [{ index: -1, message: "Request body must include a 'controls' array" }] });
     }
@@ -477,26 +479,6 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
       return res.status(400).json({ success: false, errors });
     }
 
-    await client.query("BEGIN");
-    const user = (req as any).user;
-
-    const controlIds = parsedWithIndex.map((p) => p.data.control_id);
-    const existingIds = await client.query(
-      "SELECT control_id FROM crc_controls WHERE control_id = ANY($1)",
-      [controlIds]
-    );
-    const existingSet = new Set(existingIds.rows.map((r: { control_id: string }) => r.control_id));
-    for (const { data, originalIndex } of parsedWithIndex) {
-      if (existingSet.has(data.control_id)) {
-        errors.push({ index: originalIndex, control_id: data.control_id, message: "Control ID already exists" });
-      }
-    }
-
-    if (errors.length > 0) {
-      await client.query("ROLLBACK");
-      return res.status(400).json({ success: false, errors });
-    }
-
     // Check all unique category_ids in the batch
     const uniqueCategoryIds = Array.from(new Set(parsedWithIndex.map(p => p.data.category_id)));
     const catCheck = await client.query("SELECT id FROM crc_categories WHERE id = ANY($1)", [uniqueCategoryIds]);
@@ -509,57 +491,136 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
     }
 
     if (errors.length > 0) {
+      return res.status(400).json({ success: false, errors });
+    }
+
+    await client.query("BEGIN");
+    const user = (req as any).user;
+
+    const controlIds = parsedWithIndex.map((p) => p.data.control_id);
+    const existingIds = await client.query(
+      "SELECT id, control_id, version, status FROM crc_controls WHERE control_id = ANY($1)",
+      [controlIds]
+    );
+    const existingMap = new Map<string, { id: string; control_id: string; version: number; status: string }>(
+      existingIds.rows.map((r: any) => [r.control_id, r])
+    );
+
+    if (!overwrite) {
+      for (const { data, originalIndex } of parsedWithIndex) {
+        if (existingMap.has(data.control_id)) {
+          errors.push({ index: originalIndex, control_id: data.control_id, message: "Control ID already exists" });
+        }
+      }
+    }
+
+    if (errors.length > 0) {
       await client.query("ROLLBACK");
       return res.status(400).json({ success: false, errors });
     }
 
-    const cols = 15;
-    const placeholders = parsedWithIndex.map((_, rowIdx) => {
-      const start = rowIdx * cols + 1;
-      return `($${start}, $${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, $${start + 7}, $${start + 8}, $${start + 9}, $${start + 10}::jsonb, $${start + 11}::jsonb, $${start + 12}::jsonb, $${start + 13}::jsonb, $${start + 14}, 1)`;
-    }).join(", ");
-    const batchInsertQuery = `
-      INSERT INTO crc_controls (
-        control_id, control_title, category_id, expected_timeline, priority, status, applicable_to,
-        control_statement, control_objective, risk_description,
-        implementation, evidence_requirements, compliance_mapping, aima_mapping,
-        created_by, version
-      )
-      VALUES ${placeholders}
-      RETURNING *
-    `;
-    const values: any[] = [];
-    for (const { data } of parsedWithIndex) {
-      values.push(
-        data.control_id, data.control_title, data.category_id, data.expected_timeline, data.priority, data.status, data.applicable_to,
-        data.control_statement, data.control_objective, data.risk_description,
-        JSON.stringify(data.implementation), JSON.stringify(data.evidence_requirements),
-        JSON.stringify(data.compliance_mapping), JSON.stringify(data.aima_mapping),
-        user.id
-      );
-    }
-    const result = await client.query(batchInsertQuery, values);
-    const created = result.rows;
+    const toInsert: typeof parsedWithIndex = [];
+    const toUpdate: typeof parsedWithIndex = [];
 
-    if (created.length > 0) {
-      const snapshotCols = 7;
-      const snapshotPlaceholders = created.map((_: any, i: number) => {
-        const base = i * snapshotCols + 1;
-        return `($${base}, $${base + 1}, $${base + 2}::jsonb, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`;
-      }).join(", ");
-      const snapshotValues: any[] = [];
-      for (const ctrl of created) {
-        snapshotValues.push(ctrl.id, ctrl.version, JSON.stringify(ctrl), null, ctrl.status, user.id, "Initial creation");
+    for (const item of parsedWithIndex) {
+      if (existingMap.has(item.data.control_id)) {
+        toUpdate.push(item);
+      } else {
+        toInsert.push(item);
       }
-      await client.query(
-        `INSERT INTO crc_control_versions (control_id, version, snapshot, status_from, status_to, changed_by, change_note)
-         VALUES ${snapshotPlaceholders}`,
-        snapshotValues
-      );
+    }
+
+    const processed: any[] = [];
+
+    // 1. Process inserts
+    if (toInsert.length > 0) {
+      const cols = 15;
+      const placeholders = toInsert.map((_, rowIdx) => {
+        const start = rowIdx * cols + 1;
+        return `($${start}, $${start + 1}, $${start + 2}, $${start + 3}, $${start + 4}, $${start + 5}, $${start + 6}, $${start + 7}, $${start + 8}, $${start + 9}, $${start + 10}::jsonb, $${start + 11}::jsonb, $${start + 12}::jsonb, $${start + 13}::jsonb, $${start + 14}, 1)`;
+      }).join(", ");
+      const batchInsertQuery = `
+        INSERT INTO crc_controls (
+          control_id, control_title, category_id, expected_timeline, priority, status, applicable_to,
+          control_statement, control_objective, risk_description,
+          implementation, evidence_requirements, compliance_mapping, aima_mapping,
+          created_by, version
+        )
+        VALUES ${placeholders}
+        RETURNING *
+      `;
+      const values: any[] = [];
+      for (const { data } of toInsert) {
+        values.push(
+          data.control_id, data.control_title, data.category_id, data.expected_timeline, data.priority, data.status, data.applicable_to,
+          data.control_statement, data.control_objective, data.risk_description,
+          JSON.stringify(data.implementation), JSON.stringify(data.evidence_requirements),
+          JSON.stringify(data.compliance_mapping), JSON.stringify(data.aima_mapping),
+          user.id
+        );
+      }
+      const result = await client.query(batchInsertQuery, values);
+      const createdRows = result.rows;
+      processed.push(...createdRows);
+
+      if (createdRows.length > 0) {
+        const snapshotCols = 7;
+        const snapshotPlaceholders = createdRows.map((_: any, i: number) => {
+          const base = i * snapshotCols + 1;
+          return `($${base}, $${base + 1}, $${base + 2}::jsonb, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`;
+        }).join(", ");
+        const snapshotValues: any[] = [];
+        for (const ctrl of createdRows) {
+          snapshotValues.push(ctrl.id, ctrl.version, JSON.stringify(ctrl), null, ctrl.status, user.id, "Initial creation");
+        }
+        await client.query(
+          `INSERT INTO crc_control_versions (control_id, version, snapshot, status_from, status_to, changed_by, change_note)
+           VALUES ${snapshotPlaceholders}`,
+          snapshotValues
+        );
+      }
+    }
+
+    // 2. Process updates (overwrites)
+    if (toUpdate.length > 0) {
+      for (const { data } of toUpdate) {
+        const existing = existingMap.get(data.control_id)!;
+        const newVersion = existing.version + 1;
+        
+        // Preserve existing status to respect single update flow status transition restrictions
+        const status = existing.status;
+
+        const updateQuery = `
+          UPDATE crc_controls SET
+            control_title = $1, category_id = $2, expected_timeline = $3, priority = $4, status = $5, applicable_to = $6,
+            control_statement = $7, control_objective = $8, risk_description = $9,
+            implementation = $10::jsonb, evidence_requirements = $11::jsonb, compliance_mapping = $12::jsonb, aima_mapping = $13::jsonb,
+            updated_at = CURRENT_TIMESTAMP, version = $14
+          WHERE id = $15
+          RETURNING *
+        `;
+        const values = [
+          data.control_title, data.category_id, data.expected_timeline, data.priority, status, data.applicable_to,
+          data.control_statement, data.control_objective, data.risk_description,
+          JSON.stringify(data.implementation), JSON.stringify(data.evidence_requirements),
+          JSON.stringify(data.compliance_mapping), JSON.stringify(data.aima_mapping),
+          newVersion, existing.id
+        ];
+        const result = await client.query(updateQuery, values);
+        const updatedRow = result.rows[0];
+        processed.push(updatedRow);
+
+        // Record a new version history snapshot
+        await client.query(
+          `INSERT INTO crc_control_versions (control_id, version, snapshot, status_from, status_to, changed_by, change_note)
+           VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)`,
+          [existing.id, newVersion, JSON.stringify(updatedRow), existing.status, status, user.id, "Bulk import overwrite"]
+        );
+      }
     }
 
     await client.query("COMMIT");
-    res.status(201).json({ success: true, data: created });
+    res.status(201).json({ success: true, data: processed });
   } catch (error) {
     await client.query("ROLLBACK");
     console.error("Error bulk creating controls:", error);

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -590,6 +590,39 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
         // Preserve existing status to respect single update flow status transition restrictions
         const status = existing.status;
 
+        let implementation = existing.implementation;
+        if (Object.prototype.hasOwnProperty.call(rawItem, 'implementation') && rawItem.implementation && typeof rawItem.implementation === 'object') {
+          const merged = { ...existing.implementation };
+          for (const key of Object.keys(rawItem.implementation)) {
+            if (data.implementation && Object.prototype.hasOwnProperty.call(data.implementation, key)) {
+              merged[key] = (data.implementation as any)[key];
+            }
+          }
+          implementation = merged;
+        }
+
+        let compliance_mapping = existing.compliance_mapping;
+        if (Object.prototype.hasOwnProperty.call(rawItem, 'compliance_mapping') && rawItem.compliance_mapping && typeof rawItem.compliance_mapping === 'object') {
+          const merged = { ...existing.compliance_mapping };
+          for (const key of Object.keys(rawItem.compliance_mapping)) {
+            if (data.compliance_mapping && Object.prototype.hasOwnProperty.call(data.compliance_mapping, key)) {
+              merged[key] = (data.compliance_mapping as any)[key];
+            }
+          }
+          compliance_mapping = merged;
+        }
+
+        let aima_mapping = existing.aima_mapping;
+        if (Object.prototype.hasOwnProperty.call(rawItem, 'aima_mapping') && rawItem.aima_mapping && typeof rawItem.aima_mapping === 'object') {
+          const merged = { ...existing.aima_mapping };
+          for (const key of Object.keys(rawItem.aima_mapping)) {
+            if (data.aima_mapping && Object.prototype.hasOwnProperty.call(data.aima_mapping, key)) {
+              merged[key] = (data.aima_mapping as any)[key];
+            }
+          }
+          aima_mapping = merged;
+        }
+
         // Fall back to existing values for fields the UI/payload did not send (matching single PUT behavior)
         const updatedData = {
           control_title: Object.prototype.hasOwnProperty.call(rawItem, 'control_title') ? data.control_title : existing.control_title,
@@ -600,16 +633,10 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
           control_statement: Object.prototype.hasOwnProperty.call(rawItem, 'control_statement') ? data.control_statement : existing.control_statement,
           control_objective: Object.prototype.hasOwnProperty.call(rawItem, 'control_objective') ? data.control_objective : existing.control_objective,
           risk_description: Object.prototype.hasOwnProperty.call(rawItem, 'risk_description') ? data.risk_description : existing.risk_description,
-          implementation: Object.prototype.hasOwnProperty.call(rawItem, 'implementation')
-            ? { ...existing.implementation, ...data.implementation }
-            : existing.implementation,
+          implementation,
           evidence_requirements: Object.prototype.hasOwnProperty.call(rawItem, 'evidence_requirements') ? data.evidence_requirements : existing.evidence_requirements,
-          compliance_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'compliance_mapping')
-            ? { ...existing.compliance_mapping, ...data.compliance_mapping }
-            : existing.compliance_mapping,
-          aima_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'aima_mapping')
-            ? { ...existing.aima_mapping, ...data.aima_mapping }
-            : existing.aima_mapping,
+          compliance_mapping,
+          aima_mapping,
         };
 
         const updateQuery = `

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -441,7 +441,7 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
     }
 
     const errors: { index: number; control_id?: string; message: string }[] = [];
-    const parsedWithIndex: { data: z.infer<typeof controlSchema>; originalIndex: number }[] = [];
+    const parsedWithIndex: { data: z.infer<typeof controlSchema>; rawItem: any; originalIndex: number }[] = [];
 
     for (let i = 0; i < raw.controls.length; i++) {
       const item = raw.controls[i];
@@ -458,7 +458,7 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
         errors.push({ index: i, control_id: item?.control_id, message: first?.message || "Validation failed" });
         continue;
       }
-      parsedWithIndex.push({ data: result.data, originalIndex: i });
+      parsedWithIndex.push({ data: result.data, rawItem: item, originalIndex: i });
     }
 
     const idToIndices = new Map<string, number[]>();
@@ -499,10 +499,10 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
 
     const controlIds = parsedWithIndex.map((p) => p.data.control_id);
     const existingIds = await client.query(
-      "SELECT id, control_id, version, status FROM crc_controls WHERE control_id = ANY($1)",
+      "SELECT * FROM crc_controls WHERE control_id = ANY($1) FOR UPDATE",
       [controlIds]
     );
-    const existingMap = new Map<string, { id: string; control_id: string; version: number; status: string }>(
+    const existingMap = new Map<string, any>(
       existingIds.rows.map((r: any) => [r.control_id, r])
     );
 
@@ -583,12 +583,34 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
 
     // 2. Process updates (overwrites)
     if (toUpdate.length > 0) {
-      for (const { data } of toUpdate) {
+      for (const { data, rawItem } of toUpdate) {
         const existing = existingMap.get(data.control_id)!;
         const newVersion = existing.version + 1;
         
         // Preserve existing status to respect single update flow status transition restrictions
         const status = existing.status;
+
+        // Fall back to existing values for fields the UI/payload did not send (matching single PUT behavior)
+        const updatedData = {
+          control_title: Object.prototype.hasOwnProperty.call(rawItem, 'control_title') ? data.control_title : existing.control_title,
+          category_id: Object.prototype.hasOwnProperty.call(rawItem, 'category_id') ? data.category_id : existing.category_id,
+          expected_timeline: Object.prototype.hasOwnProperty.call(rawItem, 'expected_timeline') ? data.expected_timeline : existing.expected_timeline,
+          priority: Object.prototype.hasOwnProperty.call(rawItem, 'priority') ? data.priority : existing.priority,
+          applicable_to: Object.prototype.hasOwnProperty.call(rawItem, 'applicable_to') ? data.applicable_to : existing.applicable_to,
+          control_statement: Object.prototype.hasOwnProperty.call(rawItem, 'control_statement') ? data.control_statement : existing.control_statement,
+          control_objective: Object.prototype.hasOwnProperty.call(rawItem, 'control_objective') ? data.control_objective : existing.control_objective,
+          risk_description: Object.prototype.hasOwnProperty.call(rawItem, 'risk_description') ? data.risk_description : existing.risk_description,
+          implementation: Object.prototype.hasOwnProperty.call(rawItem, 'implementation')
+            ? { ...existing.implementation, ...rawItem.implementation }
+            : existing.implementation,
+          evidence_requirements: Object.prototype.hasOwnProperty.call(rawItem, 'evidence_requirements') ? data.evidence_requirements : existing.evidence_requirements,
+          compliance_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'compliance_mapping')
+            ? { ...existing.compliance_mapping, ...rawItem.compliance_mapping }
+            : existing.compliance_mapping,
+          aima_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'aima_mapping')
+            ? { ...existing.aima_mapping, ...rawItem.aima_mapping }
+            : existing.aima_mapping,
+        };
 
         const updateQuery = `
           UPDATE crc_controls SET
@@ -600,10 +622,10 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
           RETURNING *
         `;
         const values = [
-          data.control_title, data.category_id, data.expected_timeline, data.priority, status, data.applicable_to,
-          data.control_statement, data.control_objective, data.risk_description,
-          JSON.stringify(data.implementation), JSON.stringify(data.evidence_requirements),
-          JSON.stringify(data.compliance_mapping), JSON.stringify(data.aima_mapping),
+          updatedData.control_title, updatedData.category_id, updatedData.expected_timeline, updatedData.priority, status, updatedData.applicable_to,
+          updatedData.control_statement, updatedData.control_objective, updatedData.risk_description,
+          JSON.stringify(updatedData.implementation), JSON.stringify(updatedData.evidence_requirements),
+          JSON.stringify(updatedData.compliance_mapping), JSON.stringify(updatedData.aima_mapping),
           newVersion, existing.id
         ];
         const result = await client.query(updateQuery, values);

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -601,14 +601,14 @@ router.post("/controls/bulk", authenticateToken, requireRole(["ADMIN"]), async (
           control_objective: Object.prototype.hasOwnProperty.call(rawItem, 'control_objective') ? data.control_objective : existing.control_objective,
           risk_description: Object.prototype.hasOwnProperty.call(rawItem, 'risk_description') ? data.risk_description : existing.risk_description,
           implementation: Object.prototype.hasOwnProperty.call(rawItem, 'implementation')
-            ? { ...existing.implementation, ...rawItem.implementation }
+            ? { ...existing.implementation, ...data.implementation }
             : existing.implementation,
           evidence_requirements: Object.prototype.hasOwnProperty.call(rawItem, 'evidence_requirements') ? data.evidence_requirements : existing.evidence_requirements,
           compliance_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'compliance_mapping')
-            ? { ...existing.compliance_mapping, ...rawItem.compliance_mapping }
+            ? { ...existing.compliance_mapping, ...data.compliance_mapping }
             : existing.compliance_mapping,
           aima_mapping: Object.prototype.hasOwnProperty.call(rawItem, 'aima_mapping')
-            ? { ...existing.aima_mapping, ...rawItem.aima_mapping }
+            ? { ...existing.aima_mapping, ...data.aima_mapping }
             : existing.aima_mapping,
         };
 

--- a/frontend/src/app/admin/crc/page.tsx
+++ b/frontend/src/app/admin/crc/page.tsx
@@ -319,7 +319,8 @@ export default function CRCAdminPage() {
     const [bulkEditIndex, setBulkEditIndex] = useState<number | null>(null);
     const [bulkEditFormData, setBulkEditFormData] = useState<Partial<Control>>(defaultControlState);
     const [bulkImporting, setBulkImporting] = useState(false);
-    const [bulkOverwrite, setBulkOverwrite] = useState(false);
+    const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
+    const [pendingPayloads, setPendingPayloads] = useState<any[]>([]);
     
     // Category management state
     const [showCategoryDialog, setShowCategoryDialog] = useState(false);
@@ -597,7 +598,8 @@ export default function CRCAdminPage() {
         setBulkPreviewRows([]);
         setBulkErrors([]);
         setBulkEditIndex(null);
-        setBulkOverwrite(false);
+        setShowOverwriteConfirm(false);
+        setPendingPayloads([]);
     };
 
     const parseBulkFromPaste = (): Partial<Control>[] => {
@@ -879,9 +881,55 @@ export default function CRCAdminPage() {
                 };
             });
 
-            const { data } = await apiService.createCRCBulk(payloads, bulkOverwrite);
+            const { data } = await apiService.createCRCBulk(payloads, false);
             toast.success(`Successfully imported ${data.length} controls.`);
             setShowBulkDialog(false);
+            fetchControls();
+        } catch (err: any) {
+            if (err?.errors?.length) {
+                const hasDuplicateError = err.errors.some((e: any) => e.message === "Control ID already exists");
+                if (hasDuplicateError) {
+                    const payloads = bulkPreviewRows.map((r) => {
+                        const catId = r.category_id !== undefined ? r.category_id : categories[0]?.id;
+                        return {
+                            control_id: r.control_id as string,
+                            control_title: r.control_title as string,
+                            category_id: catId,
+                            priority: r.priority && PRIORITIES.includes(r.priority) ? r.priority : "Medium",
+                            status: r.status || "Draft",
+                            applicable_to: r.applicable_to ?? [],
+                            expected_timeline: r.expected_timeline ?? "",
+                            control_statement: r.control_statement ?? "",
+                            control_objective: r.control_objective ?? "",
+                            risk_description: r.risk_description ?? "",
+                            implementation: r.implementation ?? { requirements: [], steps: [] },
+                            evidence_requirements: r.evidence_requirements ?? [],
+                            compliance_mapping: r.compliance_mapping ?? { eu_ai_act: [], nist_ai_rmf: [], iso_42001: [] },
+                        };
+                    });
+                    setPendingPayloads(payloads);
+                    setShowOverwriteConfirm(true);
+                } else {
+                    setBulkErrors(err.errors);
+                    toast.error(`Import failed: ${err.errors.length} row(s) have errors. Fix or remove them and try again.`);
+                }
+            } else {
+                toast.error(err?.message || "Bulk import failed");
+            }
+        } finally {
+            setBulkImporting(false);
+        }
+    };
+
+    const confirmOverwriteImport = async () => {
+        if (pendingPayloads.length === 0) return;
+        setBulkImporting(true);
+        try {
+            const { data } = await apiService.createCRCBulk(pendingPayloads, true);
+            toast.success(`Successfully imported ${data.length} controls.`);
+            setShowOverwriteConfirm(false);
+            setShowBulkDialog(false);
+            setPendingPayloads([]);
             fetchControls();
         } catch (err: any) {
             if (err?.errors?.length) {
@@ -890,6 +938,7 @@ export default function CRCAdminPage() {
             } else {
                 toast.error(err?.message || "Bulk import failed");
             }
+            setShowOverwriteConfirm(false);
         } finally {
             setBulkImporting(false);
         }
@@ -1594,24 +1643,9 @@ export default function CRCAdminPage() {
                                     )}
                                 </TabsContent>
                             </Tabs>
-                            <div className="flex items-center justify-between pt-2 border-t">
-                                <div className="flex items-center space-x-2">
-                                    <Checkbox
-                                        id="bulk-overwrite-input"
-                                        checked={bulkOverwrite}
-                                        onCheckedChange={(checked) => setBulkOverwrite(!!checked)}
-                                    />
-                                    <label
-                                        htmlFor="bulk-overwrite-input"
-                                        className="text-sm font-medium leading-none cursor-pointer select-none"
-                                    >
-                                        Overwrite duplicate Control IDs (update existing controls instead of failing)
-                                    </label>
-                                </div>
-                                <div className="flex gap-2">
-                                    <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
-                                    <Button onClick={handleBulkParse}>Parse and preview</Button>
-                                </div>
+                            <div className="flex justify-end gap-2 pt-2 border-t">
+                                <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
+                                <Button onClick={handleBulkParse}>Parse and preview</Button>
                             </div>
                         </div>
                     ) : (
@@ -1658,29 +1692,36 @@ export default function CRCAdminPage() {
                                     </TableBody>
                                 </Table>
                             </div>
-                            <div className="flex items-center justify-between pt-4 border-t">
-                                <div className="flex items-center space-x-2">
-                                    <Checkbox
-                                        id="bulk-overwrite-preview"
-                                        checked={bulkOverwrite}
-                                        onCheckedChange={(checked) => setBulkOverwrite(!!checked)}
-                                    />
-                                    <label
-                                        htmlFor="bulk-overwrite-preview"
-                                        className="text-sm font-medium leading-none cursor-pointer select-none"
-                                    >
-                                        Overwrite duplicate Control IDs (update existing controls instead of failing)
-                                    </label>
-                                </div>
-                                <div className="flex gap-2">
-                                    <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
-                                    <Button onClick={handleBulkImport} disabled={bulkPreviewRows.length === 0 || bulkImporting}>
-                                        {bulkImporting ? "Importing..." : `Import ${bulkPreviewRows.length} control(s)`}
-                                    </Button>
-                                </div>
+                            <div className="flex justify-end gap-2 pt-4 border-t">
+                                <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
+                                <Button onClick={handleBulkImport} disabled={bulkPreviewRows.length === 0 || bulkImporting}>
+                                    {bulkImporting ? "Importing..." : `Import ${bulkPreviewRows.length} control(s)`}
+                                </Button>
                             </div>
                         </div>
                     )}
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={showOverwriteConfirm} onOpenChange={setShowOverwriteConfirm}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Overwrite Existing Controls?</DialogTitle>
+                        <DialogDescription>
+                            Some of the controls you are importing already exist in the database. Do you want to overwrite their details and increment their versions?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => {
+                            setShowOverwriteConfirm(false);
+                            setPendingPayloads([]);
+                        }}>
+                            No, Cancel
+                        </Button>
+                        <Button onClick={confirmOverwriteImport} disabled={bulkImporting}>
+                            {bulkImporting ? "Importing..." : "Yes, Overwrite"}
+                        </Button>
+                    </DialogFooter>
                 </DialogContent>
             </Dialog>
 

--- a/frontend/src/app/admin/crc/page.tsx
+++ b/frontend/src/app/admin/crc/page.tsx
@@ -319,6 +319,7 @@ export default function CRCAdminPage() {
     const [bulkEditIndex, setBulkEditIndex] = useState<number | null>(null);
     const [bulkEditFormData, setBulkEditFormData] = useState<Partial<Control>>(defaultControlState);
     const [bulkImporting, setBulkImporting] = useState(false);
+    const [bulkOverwrite, setBulkOverwrite] = useState(false);
     
     // Category management state
     const [showCategoryDialog, setShowCategoryDialog] = useState(false);
@@ -596,6 +597,7 @@ export default function CRCAdminPage() {
         setBulkPreviewRows([]);
         setBulkErrors([]);
         setBulkEditIndex(null);
+        setBulkOverwrite(false);
     };
 
     const parseBulkFromPaste = (): Partial<Control>[] => {
@@ -877,8 +879,8 @@ export default function CRCAdminPage() {
                 };
             });
 
-            const { data } = await apiService.createCRCBulk(payloads);
-            toast.success(`Created ${data.length} controls. You can edit or delete any control from the list.`);
+            const { data } = await apiService.createCRCBulk(payloads, bulkOverwrite);
+            toast.success(`Successfully imported ${data.length} controls.`);
             setShowBulkDialog(false);
             fetchControls();
         } catch (err: any) {
@@ -1592,9 +1594,24 @@ export default function CRCAdminPage() {
                                     )}
                                 </TabsContent>
                             </Tabs>
-                            <div className="flex justify-end gap-2">
-                                <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
-                                <Button onClick={handleBulkParse}>Parse and preview</Button>
+                            <div className="flex items-center justify-between pt-2 border-t">
+                                <div className="flex items-center space-x-2">
+                                    <Checkbox
+                                        id="bulk-overwrite-input"
+                                        checked={bulkOverwrite}
+                                        onCheckedChange={(checked) => setBulkOverwrite(!!checked)}
+                                    />
+                                    <label
+                                        htmlFor="bulk-overwrite-input"
+                                        className="text-sm font-medium leading-none cursor-pointer select-none"
+                                    >
+                                        Overwrite duplicate Control IDs (update existing controls instead of failing)
+                                    </label>
+                                </div>
+                                <div className="flex gap-2">
+                                    <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
+                                    <Button onClick={handleBulkParse}>Parse and preview</Button>
+                                </div>
                             </div>
                         </div>
                     ) : (
@@ -1641,12 +1658,27 @@ export default function CRCAdminPage() {
                                     </TableBody>
                                 </Table>
                             </div>
-                            <DialogFooter>
-                                <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
-                                <Button onClick={handleBulkImport} disabled={bulkPreviewRows.length === 0 || bulkImporting}>
-                                    {bulkImporting ? "Importing..." : `Import ${bulkPreviewRows.length} control(s)`}
-                                </Button>
-                            </DialogFooter>
+                            <div className="flex items-center justify-between pt-4 border-t">
+                                <div className="flex items-center space-x-2">
+                                    <Checkbox
+                                        id="bulk-overwrite-preview"
+                                        checked={bulkOverwrite}
+                                        onCheckedChange={(checked) => setBulkOverwrite(!!checked)}
+                                    />
+                                    <label
+                                        htmlFor="bulk-overwrite-preview"
+                                        className="text-sm font-medium leading-none cursor-pointer select-none"
+                                    >
+                                        Overwrite duplicate Control IDs (update existing controls instead of failing)
+                                    </label>
+                                </div>
+                                <div className="flex gap-2">
+                                    <Button variant="outline" onClick={() => setShowBulkDialog(false)}>Cancel</Button>
+                                    <Button onClick={handleBulkImport} disabled={bulkPreviewRows.length === 0 || bulkImporting}>
+                                        {bulkImporting ? "Importing..." : `Import ${bulkPreviewRows.length} control(s)`}
+                                    </Button>
+                                </div>
+                            </div>
                         </div>
                     )}
                 </DialogContent>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1559,13 +1559,13 @@ class ApiService {
   }
 
   /** Bulk create CRC controls. On 400, throws an error with .status and .errors: { index, control_id?, message }[] */
-  async createCRCBulk(controls: Partial<CRCControl>[]): Promise<{ data: CRCControl[] }> {
+  async createCRCBulk(controls: Partial<CRCControl>[], overwrite?: boolean): Promise<{ data: CRCControl[] }> {
     let response: Response;
     try {
       response = await fetch(`${API_BASE_URL}/crc/controls/bulk`, {
         method: "POST",
         headers: this.getHeaders(),
-        body: JSON.stringify({ controls }),
+        body: JSON.stringify({ controls, overwrite }),
       });
     } catch (networkError) {
       const err = new Error("Network error") as Error & { status?: number; errors?: Array<{ index: number; control_id?: string; message: string }> };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk CRC uploads can now optionally overwrite existing controls that match uploaded IDs.
  * The bulk upload flow now includes an overwrite-confirmation dialog instead of a preset “overwrite duplicates” toggle.

* **Bug Fixes**
  * Bulk imports now validate that uploaded category IDs are valid before processing.
  * When overwriting, existing controls keep their current workflow status while version history is updated.

* **User Experience**
  * Import feedback now reports: “Successfully imported … controls.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->