### PR TITLE
feat: implement admin templates bulk upload and matching

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@types/nodemailer": "^7.0.2",
         "@types/qrcode": "^1.5.5",
         "@types/speakeasy": "^2.0.10",
+        "adm-zip": "^0.5.17",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -32,6 +33,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.8",
         "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -4968,6 +4970,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.152",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
@@ -5325,6 +5337,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@types/nodemailer": "^7.0.2",
     "@types/qrcode": "^1.5.5",
     "@types/speakeasy": "^2.0.10",
+    "adm-zip": "^0.5.17",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
@@ -37,6 +38,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -9,6 +9,7 @@ import { recordEvent } from "../services/auditLogService";
 import fs from "fs";
 import path from "path";
 import multer from "multer";
+import AdmZip from "adm-zip";
 import { syncRiskFromResponse } from "../services/crcRiskService";
 import crypto from "crypto";
 import { inngest } from "../inngest/client";
@@ -62,6 +63,29 @@ const templateUpload = multer({
       cb(null, true);
     } else {
       cb(new Error("Only .doc and .docx files are allowed"));
+    }
+  },
+});
+
+const bulkTemplateUpload = multer({
+  storage: templateStorage,
+  limits: { fileSize: 100 * 1024 * 1024 }, // 100MB max
+  fileFilter: (_req, file, cb) => {
+    const allowed = [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+      "application/msword", // .doc
+      "application/zip", // .zip
+      "application/x-zip-compressed", // .zip (Windows/some systems)
+    ];
+    if (
+      allowed.includes(file.mimetype) ||
+      file.originalname.endsWith(".docx") ||
+      file.originalname.endsWith(".doc") ||
+      file.originalname.endsWith(".zip")
+    ) {
+      cb(null, true);
+    } else {
+      cb(new Error("Only .doc, .docx, and .zip files are allowed"));
     }
   },
 });
@@ -1805,6 +1829,231 @@ router.get("/templates/status", authenticateToken, requireRole(["ADMIN"]), async
   } catch (error) {
     console.error("Error fetching template statuses:", error);
     res.status(500).json({ success: false, error: "Failed to fetch template statuses" });
+  }
+});
+
+// POST /crc/templates/bulk-upload - Bulk upload compliance template documents (Admin only)
+router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]), (req, res, next) => {
+  bulkTemplateUpload.array("files", 150)(req, res, (err: any) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(400).json({ success: false, error: "File size exceeds 100MB limit" });
+      }
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    if (err) {
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    next();
+  });
+}, async (req, res) => {
+  const uploadedFiles = req.files as Express.Multer.File[] | undefined;
+  if (!uploadedFiles || uploadedFiles.length === 0) {
+    return res.status(400).json({ success: false, error: "No files uploaded." });
+  }
+
+  // Temporary folders created for extracting ZIP files
+  const tempFolders: string[] = [];
+  // All template files to process (either direct uploads or extracted from ZIPs)
+  const templatesToProcess: { filePath: string; originalname: string; mimetype: string; size: number; isTemp: boolean }[] = [];
+
+  try {
+    // 1. Fetch all valid control IDs from database to match against filenames
+    const controlsResult = await pool.query("SELECT control_id FROM crc_controls");
+    const validControlIds = controlsResult.rows.map((r: { control_id: string }) => r.control_id);
+    
+    // Sort control IDs by length in descending order to match the longest (most specific) first
+    // E.g., match "GOV-3P-010" before "GOV-3P-01"
+    validControlIds.sort((a, b) => b.length - a.length);
+
+    // 2. Classify and process each uploaded file
+    for (const file of uploadedFiles) {
+      const isZip = file.mimetype === "application/zip" || 
+                    file.mimetype === "application/x-zip-compressed" || 
+                    file.originalname.toLowerCase().endsWith(".zip");
+
+      if (isZip) {
+        // Extract ZIP contents
+        const zipPath = file.path;
+        const extractDir = path.join(TEMPLATES_DIR, `bulk_extract_${Date.now()}_${crypto.randomUUID()}`);
+        fs.mkdirSync(extractDir, { recursive: true });
+        tempFolders.push(extractDir);
+
+        const zip = new AdmZip(zipPath);
+        zip.extractAllTo(extractDir, true);
+
+        // Recursively read extracted files
+        const readFilesRecursively = (dir: string) => {
+          const entries = fs.readdirSync(dir, { withFileTypes: true });
+          for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+              readFilesRecursively(fullPath);
+            } else if (entry.isFile() && (entry.name.toLowerCase().endsWith(".docx") || entry.name.toLowerCase().endsWith(".doc"))) {
+              const stats = fs.statSync(fullPath);
+              templatesToProcess.push({
+                filePath: fullPath,
+                originalname: entry.name,
+                mimetype: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                size: stats.size,
+                isTemp: true, // We need to delete this file later because it was extracted
+              });
+            }
+          }
+        };
+        readFilesRecursively(extractDir);
+      } else {
+        // Direct .docx / .doc file
+        templatesToProcess.push({
+          filePath: file.path,
+          originalname: file.originalname,
+          mimetype: file.mimetype,
+          size: file.size,
+          isTemp: false, // Will be deleted at the end as part of standard multer file cleanups
+        });
+      }
+    }
+
+    if (templatesToProcess.length === 0) {
+      return res.status(400).json({ success: false, error: "No valid .doc or .docx template files found in the upload." });
+    }
+
+    // 3. Process each template file
+    const results: { filename: string; status: "success" | "unmatched" | "failed"; controlId?: string; error?: string }[] = [];
+    const FileConstructor = typeof File !== "undefined" ? File : require("node:buffer").File;
+    const user = (req as any).user;
+
+    for (const template of templatesToProcess) {
+      const filenameUpper = template.originalname.toUpperCase();
+      let matchedControlId: string | null = null;
+
+      // Find the first (longest) control_id that appears in the filename
+      for (const controlId of validControlIds) {
+        if (filenameUpper.includes(controlId.toUpperCase())) {
+          matchedControlId = controlId;
+          break;
+        }
+      }
+
+      if (!matchedControlId) {
+        results.push({
+          filename: template.originalname,
+          status: "unmatched",
+          error: "Filename does not match any valid control ID in the database.",
+        });
+        continue;
+      }
+
+      try {
+        const fileData = fs.readFileSync(template.filePath);
+        const webFile = new FileConstructor([fileData], template.originalname, { type: template.mimetype });
+
+        // Upload to UploadThing
+        const uploadResult = await utapi.uploadFiles(webFile);
+
+        if (!uploadResult || !uploadResult.data) {
+          const errorMsg = (uploadResult as any).error?.message || "Failed to upload file to cloud storage";
+          throw new Error(errorMsg);
+        }
+
+        const { url, key: fileKey } = uploadResult.data;
+
+        // Check for existing database record to clean up superseded files from UploadThing
+        const existingResult = await pool.query(
+          "SELECT file_key FROM crc_control_templates WHERE control_id = $1",
+          [matchedControlId]
+        );
+        const oldKey = existingResult.rows.length > 0 ? existingResult.rows[0].file_key : null;
+
+        // Save or update mapping in database
+        await pool.query(
+          `INSERT INTO crc_control_templates (control_id, url, file_key, filename, size, updated_at)
+           VALUES ($1, $2, $3, $4, $5, NOW())
+           ON CONFLICT (control_id)
+           DO UPDATE SET url = $2, file_key = $3, filename = $4, size = $5, updated_at = NOW()`,
+          [matchedControlId, url, fileKey, template.originalname, template.size]
+        );
+
+        // Delete superseded file from UploadThing only AFTER database upsert succeeds
+        if (oldKey) {
+          try {
+            await utapi.deleteFiles(oldKey);
+          } catch (deleteErr) {
+            console.error(`Failed to delete superseded template from UploadThing: ${oldKey}`, deleteErr);
+          }
+        }
+
+        // Try to remove local legacy files for this control to keep the local filesystem pristine
+        for (const legacyExt of [".docx", ".doc"]) {
+          const legacyPath = path.join(TEMPLATES_DIR, `${matchedControlId}${legacyExt}`);
+          if (fs.existsSync(legacyPath)) {
+            try { fs.unlinkSync(legacyPath); } catch {}
+          }
+        }
+
+        // Log audit log event
+        await recordEvent({
+          projectId: null,
+          actorId: user?.id,
+          action: "UPLOAD_CRC_TEMPLATE",
+          objectType: "CRC_CONTROL",
+          objectId: matchedControlId,
+          metadata: { filename: template.originalname, source: "bulk-uploadthing" },
+        });
+
+        results.push({
+          filename: template.originalname,
+          status: "success",
+          controlId: matchedControlId,
+        });
+
+      } catch (uploadErr: any) {
+        console.error(`Error processing template ${template.originalname} for control ${matchedControlId}:`, uploadErr);
+        results.push({
+          filename: template.originalname,
+          status: "failed",
+          controlId: matchedControlId,
+          error: uploadErr.message || "Failed during upload or database save",
+        });
+      }
+    }
+
+    const summary = {
+      total: templatesToProcess.length,
+      success: results.filter(r => r.status === "success").length,
+      unmatched: results.filter(r => r.status === "unmatched").length,
+      failed: results.filter(r => r.status === "failed").length,
+    };
+
+    res.json({
+      success: true,
+      message: `Bulk template upload finished. Success: ${summary.success}, Unmatched: ${summary.unmatched}, Failed: ${summary.failed}`,
+      summary,
+      details: results,
+    });
+
+  } catch (error) {
+    console.error("Fatal error in bulk template upload:", error);
+    res.status(500).json({ success: false, error: "Fatal error processing bulk templates" });
+  } finally {
+    // 4. Cleanup all temporary files and extracted directories
+    if (uploadedFiles) {
+      for (const file of uploadedFiles) {
+        if (fs.existsSync(file.path)) {
+          try { fs.unlinkSync(file.path); } catch {}
+        }
+      }
+    }
+
+    for (const folder of tempFolders) {
+      if (fs.existsSync(folder)) {
+        try {
+          fs.rmSync(folder, { recursive: true, force: true });
+        } catch (rmErr) {
+          console.error(`Failed to clean up temporary folder: ${folder}`, rmErr);
+        }
+      }
+    }
   }
 });
 

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -69,7 +69,10 @@ const templateUpload = multer({
 
 const bulkTemplateUpload = multer({
   storage: templateStorage,
-  limits: { fileSize: 100 * 1024 * 1024 }, // 100MB max
+  limits: {
+    fileSize: 25 * 1024 * 1024, // 25MB max per file
+    files: 160, // Max 160 files per request
+  },
   fileFilter: (_req, file, cb) => {
     const allowed = [
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
@@ -1834,10 +1837,10 @@ router.get("/templates/status", authenticateToken, requireRole(["ADMIN"]), async
 
 // POST /crc/templates/bulk-upload - Bulk upload compliance template documents (Admin only)
 router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]), (req, res, next) => {
-  bulkTemplateUpload.array("files", 150)(req, res, (err: any) => {
+  bulkTemplateUpload.array("files", 140)(req, res, (err: any) => {
     if (err instanceof multer.MulterError) {
       if (err.code === "LIMIT_FILE_SIZE") {
-        return res.status(400).json({ success: false, error: "File size exceeds 100MB limit" });
+        return res.status(400).json({ success: false, error: "File size exceeds 25MB limit" });
       }
       return res.status(400).json({ success: false, error: err.message });
     }
@@ -1880,21 +1883,55 @@ router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]),
         tempFolders.push(extractDir);
 
         const zip = new AdmZip(zipPath);
-        zip.extractAllTo(extractDir, true);
+        const entries = zip.getEntries();
+        
+        // Safety limits to prevent ZIP bombs or excessive uncompressed extraction
+        const MAX_ZIP_ENTRIES = 150;
+        const MAX_ZIP_UNCOMPRESSED_SIZE = 100 * 1024 * 1024; // 100MB
+        
+        let totalUncompressedSize = 0;
+        let fileEntryCount = 0;
+        
+        for (const entry of entries) {
+          if (!entry.isDirectory) {
+            fileEntryCount++;
+            totalUncompressedSize += entry.header.size;
+          }
+        }
+        
+        if (fileEntryCount > MAX_ZIP_ENTRIES) {
+          throw new Error(`ZIP archive contains too many files (max: ${MAX_ZIP_ENTRIES})`);
+        }
+        if (totalUncompressedSize > MAX_ZIP_UNCOMPRESSED_SIZE) {
+          throw new Error(`ZIP archive uncompressed size exceeds limit (max: 100MB)`);
+        }
+
+        // Pre-scan, filter and extract only allowed .doc/.docx template files
+        for (const entry of entries) {
+          if (entry.isDirectory) continue;
+          
+          const nameLower = entry.name.toLowerCase();
+          const isAllowedTemplate = nameLower.endsWith(".docx") || nameLower.endsWith(".doc");
+          
+          if (isAllowedTemplate) {
+            zip.extractEntryTo(entry, extractDir, true, true);
+          }
+        }
 
         // Recursively read extracted files
         const readFilesRecursively = (dir: string) => {
-          const entries = fs.readdirSync(dir, { withFileTypes: true });
-          for (const entry of entries) {
+          const entriesInDir = fs.readdirSync(dir, { withFileTypes: true });
+          for (const entry of entriesInDir) {
             const fullPath = path.join(dir, entry.name);
             if (entry.isDirectory()) {
               readFilesRecursively(fullPath);
             } else if (entry.isFile() && (entry.name.toLowerCase().endsWith(".docx") || entry.name.toLowerCase().endsWith(".doc"))) {
               const stats = fs.statSync(fullPath);
+              const isDoc = entry.name.toLowerCase().endsWith(".doc");
               templatesToProcess.push({
                 filePath: fullPath,
                 originalname: entry.name,
-                mimetype: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                mimetype: isDoc ? "application/msword" : "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 size: stats.size,
                 isTemp: true, // We need to delete this file later because it was extracted
               });
@@ -1918,22 +1955,55 @@ router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]),
       return res.status(400).json({ success: false, error: "No valid .doc or .docx template files found in the upload." });
     }
 
-    // 3. Process each template file
+    // 3. Precompute and validate template-to-control ID matches
+    // Require bounded token-style matches and reject any ambiguous or duplicate template-to-control assignments
+    const templateMappings = new Map<string, { filename: string; templateIdx: number }>();
+    const validationErrors: string[] = [];
+    const matchedControlIdsForTemplates = new Map<number, string>(); // index in templatesToProcess -> control_id
+
+    for (let i = 0; i < templatesToProcess.length; i++) {
+      const template = templatesToProcess[i];
+      const matchedControls: string[] = [];
+
+      for (const controlId of validControlIds) {
+        // Bounded token-style match to prevent matching partial substrings (e.g. matching GOV-3P-01 inside GOV-3P-010)
+        const escaped = controlId.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+        const regex = new RegExp(`(?:^|[^A-Z0-9])${escaped}(?:$|[^A-Z0-9])`, 'i');
+        if (regex.test(template.originalname)) {
+          matchedControls.push(controlId);
+        }
+      }
+
+      if (matchedControls.length > 1) {
+        validationErrors.push(`Ambiguous match: File "${template.originalname}" matches multiple control IDs (${matchedControls.join(", ")})`);
+      } else if (matchedControls.length === 1) {
+        const matchedId = matchedControls[0];
+        const existing = templateMappings.get(matchedId);
+        if (existing) {
+          validationErrors.push(`Duplicate template assignment: Both "${existing.filename}" and "${template.originalname}" map to control ID "${matchedId}"`);
+        } else {
+          templateMappings.set(matchedId, { filename: template.originalname, templateIdx: i });
+          matchedControlIdsForTemplates.set(i, matchedId);
+        }
+      }
+      // If matchedControls.length === 0, it is unmatched, which we report as unmatched in the response details list
+    }
+
+    if (validationErrors.length > 0) {
+      return res.status(400).json({
+        success: false,
+        error: "Validation failed: " + validationErrors.join("; ")
+      });
+    }
+
+    // 4. Process each template file after passing pre-validation
     const results: { filename: string; status: "success" | "unmatched" | "failed"; controlId?: string; error?: string }[] = [];
     const FileConstructor = typeof File !== "undefined" ? File : require("node:buffer").File;
     const user = (req as any).user;
 
-    for (const template of templatesToProcess) {
-      const filenameUpper = template.originalname.toUpperCase();
-      let matchedControlId: string | null = null;
-
-      // Find the first (longest) control_id that appears in the filename
-      for (const controlId of validControlIds) {
-        if (filenameUpper.includes(controlId.toUpperCase())) {
-          matchedControlId = controlId;
-          break;
-        }
-      }
+    for (let i = 0; i < templatesToProcess.length; i++) {
+      const template = templatesToProcess[i];
+      const matchedControlId = matchedControlIdsForTemplates.get(i);
 
       if (!matchedControlId) {
         results.push({
@@ -1984,22 +2054,30 @@ router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]),
         }
 
         // Try to remove local legacy files for this control to keep the local filesystem pristine
-        for (const legacyExt of [".docx", ".doc"]) {
-          const legacyPath = path.join(TEMPLATES_DIR, `${matchedControlId}${legacyExt}`);
-          if (fs.existsSync(legacyPath)) {
-            try { fs.unlinkSync(legacyPath); } catch {}
+        for (const legacyExt of [".docx", ".doc"] as const) {
+          try {
+            const legacyPath = resolveTemplatePath(matchedControlId, legacyExt);
+            if (fs.existsSync(legacyPath)) {
+              fs.unlinkSync(legacyPath);
+            }
+          } catch (resolveErr) {
+            console.error(`Skipping legacy file cleanup for ${matchedControlId} with extension ${legacyExt}:`, resolveErr);
           }
         }
 
-        // Log audit log event
-        await recordEvent({
-          projectId: null,
-          actorId: user?.id,
-          action: "UPLOAD_CRC_TEMPLATE",
-          objectType: "CRC_CONTROL",
-          objectId: matchedControlId,
-          metadata: { filename: template.originalname, source: "bulk-uploadthing" },
-        });
+        // Log audit log event separately wrapped in its own try/catch to not block the request outcome
+        try {
+          await recordEvent({
+            projectId: null,
+            actorId: user?.id,
+            action: "UPLOAD_CRC_TEMPLATE",
+            objectType: "CRC_CONTROL",
+            objectId: matchedControlId,
+            metadata: { filename: template.originalname, source: "bulk-uploadthing" },
+          });
+        } catch (auditErr) {
+          console.error(`Failed to log audit event for template upload of control ${matchedControlId}:`, auditErr);
+        }
 
         results.push({
           filename: template.originalname,
@@ -2595,22 +2673,30 @@ router.post("/templates/:controlId/upload", authenticateToken, requireRole(["ADM
     }
 
     // Try to remove local legacy files for this control to keep the local filesystem pristine
-    for (const legacyExt of [".docx", ".doc"]) {
-      const legacyPath = path.join(TEMPLATES_DIR, `${controlShortId}${legacyExt}`);
-      if (fs.existsSync(legacyPath)) {
-        try { fs.unlinkSync(legacyPath); } catch {}
+    for (const legacyExt of [".docx", ".doc"] as const) {
+      try {
+        const legacyPath = resolveTemplatePath(controlShortId, legacyExt);
+        if (fs.existsSync(legacyPath)) {
+          fs.unlinkSync(legacyPath);
+        }
+      } catch (resolveErr) {
+        console.error(`Skipping legacy file cleanup for ${controlShortId} with extension ${legacyExt}:`, resolveErr);
       }
     }
 
     const user = (req as any).user;
-    await recordEvent({
-      projectId: null,
-      actorId: user?.id,
-      action: "UPLOAD_CRC_TEMPLATE",
-      objectType: "CRC_CONTROL",
-      objectId: controlShortId,
-      metadata: { filename: tmpFile.originalname, source: "uploadthing" },
-    });
+    try {
+      await recordEvent({
+        projectId: null,
+        actorId: user?.id,
+        action: "UPLOAD_CRC_TEMPLATE",
+        objectType: "CRC_CONTROL",
+        objectId: controlShortId,
+        metadata: { filename: tmpFile.originalname, source: "uploadthing" },
+      });
+    } catch (auditErr) {
+      console.error(`Failed to log audit event for template upload of control ${controlShortId}:`, auditErr);
+    }
 
     res.json({
       success: true,

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -1869,6 +1869,10 @@ router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]),
     // E.g., match "GOV-3P-010" before "GOV-3P-01"
     validControlIds.sort((a, b) => b.length - a.length);
 
+    // Cumulative safety counters across all ZIPs in the request
+    let totalExtractedFileCount = 0;
+    let totalExtractedBytes = 0;
+
     // 2. Classify and process each uploaded file
     for (const file of uploadedFiles) {
       const isZip = file.mimetype === "application/zip" || 
@@ -1885,25 +1889,22 @@ router.post("/templates/bulk-upload", authenticateToken, requireRole(["ADMIN"]),
         const zip = new AdmZip(zipPath);
         const entries = zip.getEntries();
         
-        // Safety limits to prevent ZIP bombs or excessive uncompressed extraction
+        // Safety limits to prevent ZIP bombs or excessive uncompressed extraction (cumulative)
         const MAX_ZIP_ENTRIES = 150;
         const MAX_ZIP_UNCOMPRESSED_SIZE = 100 * 1024 * 1024; // 100MB
         
-        let totalUncompressedSize = 0;
-        let fileEntryCount = 0;
-        
         for (const entry of entries) {
           if (!entry.isDirectory) {
-            fileEntryCount++;
-            totalUncompressedSize += entry.header.size;
+            totalExtractedFileCount++;
+            totalExtractedBytes += entry.header.size;
           }
         }
         
-        if (fileEntryCount > MAX_ZIP_ENTRIES) {
-          throw new Error(`ZIP archive contains too many files (max: ${MAX_ZIP_ENTRIES})`);
+        if (totalExtractedFileCount > MAX_ZIP_ENTRIES) {
+          throw new Error(`Total files across all ZIP archives exceeds limit (max: ${MAX_ZIP_ENTRIES})`);
         }
-        if (totalUncompressedSize > MAX_ZIP_UNCOMPRESSED_SIZE) {
-          throw new Error(`ZIP archive uncompressed size exceeds limit (max: 100MB)`);
+        if (totalExtractedBytes > MAX_ZIP_UNCOMPRESSED_SIZE) {
+          throw new Error(`Total uncompressed size across all ZIP archives exceeds limit (max: 100MB)`);
         }
 
         // Pre-scan, filter and extract only allowed .doc/.docx template files

--- a/frontend/src/app/admin/crc/page.tsx
+++ b/frontend/src/app/admin/crc/page.tsx
@@ -469,6 +469,7 @@ export default function CRCAdminPage() {
         if (e.target.files) {
             const files = Array.from(e.target.files);
             setTemplateBulkFiles(prev => [...prev, ...files]);
+            e.target.value = ""; // Clear file input value to allow re-selecting the same file
         }
     };
 
@@ -1417,7 +1418,7 @@ export default function CRCAdminPage() {
                         <IconFolder className="mr-2 size-5" /> Manage Categories
                     </Button>
                     <Button variant="outline" onClick={openBulkDialog} size="lg">
-                        <IconUpload className="mr-2 size-5" /> Bulk upload
+                        <IconUpload className="mr-2 size-5" /> Bulk controls
                     </Button>
                     <Button variant="outline" onClick={() => setShowTemplateBulkDialog(true)} size="lg">
                         <IconUpload className="mr-2 size-5" /> Bulk templates

--- a/frontend/src/app/admin/crc/page.tsx
+++ b/frontend/src/app/admin/crc/page.tsx
@@ -339,6 +339,15 @@ export default function CRCAdminPage() {
     const [templateUploadTargetId, setTemplateUploadTargetId] = useState<string | null>(null); // UUID of control
     const [templateUploadTargetShortId, setTemplateUploadTargetShortId] = useState<string | null>(null); // short control_id
     
+    // Template bulk upload state
+    const [showTemplateBulkDialog, setShowTemplateBulkDialog] = useState(false);
+    const [templateBulkFiles, setTemplateBulkFiles] = useState<File[]>([]);
+    const [templateBulkUploading, setTemplateBulkUploading] = useState(false);
+    const [templateBulkResult, setTemplateBulkResult] = useState<{
+        summary: { total: number; success: number; unmatched: number; failed: number };
+        details: Array<{ filename: string; status: 'success' | 'unmatched' | 'failed'; controlId?: string; error?: string }>;
+    } | null>(null);
+
     // Template delete dialog state
     const [showTemplateDeleteDialog, setShowTemplateDeleteDialog] = useState(false);
     const [templateToDeleteId, setTemplateToDeleteId] = useState<string | null>(null);
@@ -454,6 +463,40 @@ export default function CRCAdminPage() {
             setTemplateToDeleteId(null);
             setTemplateToDeleteShortId(null);
         }
+    };
+
+    const handleTemplateBulkFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files) {
+            const files = Array.from(e.target.files);
+            setTemplateBulkFiles(prev => [...prev, ...files]);
+        }
+    };
+
+    const handleTemplateBulkRemoveFile = (index: number) => {
+        setTemplateBulkFiles(prev => prev.filter((_, i) => i !== index));
+    };
+
+    const handleTemplateBulkUpload = async () => {
+        if (templateBulkFiles.length === 0 || templateBulkUploading) return;
+        setTemplateBulkUploading(true);
+        setTemplateBulkResult(null);
+        try {
+            const res = await apiService.uploadCRCTemplatesBulk(templateBulkFiles);
+            setTemplateBulkResult(res);
+            toast.success("Bulk template upload complete");
+            fetchTemplateStatuses();
+        } catch (error: any) {
+            toast.error(error.message || "Failed to bulk upload templates");
+        } finally {
+            setTemplateBulkUploading(false);
+        }
+    };
+
+    const closeTemplateBulkDialog = () => {
+        setShowTemplateBulkDialog(false);
+        setTemplateBulkFiles([]);
+        setTemplateBulkResult(null);
+        setTemplateBulkUploading(false);
     };
 
     useEffect(() => {
@@ -1376,6 +1419,9 @@ export default function CRCAdminPage() {
                     <Button variant="outline" onClick={openBulkDialog} size="lg">
                         <IconUpload className="mr-2 size-5" /> Bulk upload
                     </Button>
+                    <Button variant="outline" onClick={() => setShowTemplateBulkDialog(true)} size="lg">
+                        <IconUpload className="mr-2 size-5" /> Bulk templates
+                    </Button>
                     <Button onClick={handleCreate} size="lg">
                         <IconPlus className="mr-2 size-5" /> Create Control
                     </Button>
@@ -1954,6 +2000,145 @@ export default function CRCAdminPage() {
                             {categoryActionLoading ? "Deleting..." : "Delete Category"}
                         </Button>
                     </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Template Bulk Upload Dialog */}
+            <Dialog open={showTemplateBulkDialog} onOpenChange={(open) => { if (!open) closeTemplateBulkDialog(); else setShowTemplateBulkDialog(true); }}>
+                <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+                    <DialogHeader>
+                        <DialogTitle>Bulk Upload Templates</DialogTitle>
+                        <DialogDescription>
+                            Upload multiple template files (.docx/.doc) or a single ZIP file containing templates. They will be automatically matched to their respective controls based on control IDs in the filenames.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {!templateBulkResult ? (
+                        <div className="space-y-6 py-4">
+                            {/* Drag and Drop Zone / File Input */}
+                            <div className="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg p-8 bg-card hover:bg-accent/30 transition-colors relative">
+                                <input
+                                    type="file"
+                                    multiple
+                                    accept=".docx,.doc,.zip,application/zip,application/x-zip-compressed"
+                                    onChange={handleTemplateBulkFileChange}
+                                    className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                                    disabled={templateBulkUploading}
+                                />
+                                <IconUpload className="size-10 text-muted-foreground mb-4" />
+                                <p className="text-sm font-medium">Click or drag files here to upload</p>
+                                <p className="text-xs text-muted-foreground mt-1">Supports multiple .docx / .doc files or a single .zip file</p>
+                            </div>
+
+                            {/* Selected Files List */}
+                            {templateBulkFiles.length > 0 && (
+                                <div className="space-y-2">
+                                    <div className="flex justify-between items-center">
+                                        <h3 className="text-sm font-semibold">Selected Files ({templateBulkFiles.length})</h3>
+                                        <Button variant="ghost" size="sm" className="h-7 text-xs text-destructive hover:bg-destructive/10" onClick={() => setTemplateBulkFiles([])} disabled={templateBulkUploading}>
+                                            Clear all
+                                        </Button>
+                                    </div>
+                                    <div className="border rounded-md divide-y max-h-48 overflow-y-auto bg-card">
+                                        {templateBulkFiles.map((file, idx) => (
+                                            <div key={idx} className="flex items-center justify-between p-2.5 text-sm">
+                                                <div className="flex items-center gap-2 min-w-0 flex-1">
+                                                    <IconFile className="size-4 shrink-0 text-muted-foreground" />
+                                                    <span className="truncate font-medium">{file.name}</span>
+                                                    <span className="text-xs text-muted-foreground shrink-0">({(file.size / 1024).toFixed(1)} KB)</span>
+                                                </div>
+                                                <Button variant="ghost" size="icon" className="size-6 text-muted-foreground hover:text-foreground" onClick={() => handleTemplateBulkRemoveFile(idx)} disabled={templateBulkUploading}>
+                                                    <IconX className="size-4" />
+                                                </Button>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+
+                            <DialogFooter>
+                                <Button variant="outline" onClick={closeTemplateBulkDialog} disabled={templateBulkUploading}>
+                                    Cancel
+                                </Button>
+                                <Button onClick={handleTemplateBulkUpload} disabled={templateBulkFiles.length === 0 || templateBulkUploading}>
+                                    {templateBulkUploading ? (
+                                        <>
+                                            <IconLoader2 className="mr-2 size-4 animate-spin" />
+                                            Uploading & Processing...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <IconUpload className="mr-2 size-4" />
+                                            Upload Templates
+                                        </>
+                                    )}
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    ) : (
+                        <div className="space-y-6 py-4">
+                            {/* Summary Card */}
+                            <div className="grid grid-cols-4 gap-4 p-4 rounded-lg bg-accent/40 border text-center">
+                                <div>
+                                    <div className="text-2xl font-bold">{templateBulkResult.summary.total}</div>
+                                    <div className="text-xs text-muted-foreground mt-1">Processed</div>
+                                </div>
+                                <div className="text-green-600 dark:text-green-400">
+                                    <div className="text-2xl font-bold">{templateBulkResult.summary.success}</div>
+                                    <div className="text-xs text-muted-foreground mt-1 font-medium">Successful</div>
+                                </div>
+                                <div className="text-amber-600 dark:text-amber-400">
+                                    <div className="text-2xl font-bold">{templateBulkResult.summary.unmatched}</div>
+                                    <div className="text-xs text-muted-foreground mt-1 font-medium">Unmatched</div>
+                                </div>
+                                <div className="text-destructive">
+                                    <div className="text-2xl font-bold">{templateBulkResult.summary.failed}</div>
+                                    <div className="text-xs text-muted-foreground mt-1 font-medium">Failed</div>
+                                </div>
+                            </div>
+
+                            {/* Details List */}
+                            <div className="space-y-2">
+                                <h3 className="text-sm font-semibold">Upload Details</h3>
+                                <div className="border rounded-md divide-y max-h-60 overflow-y-auto bg-card text-sm">
+                                    {templateBulkResult.details.map((detail, idx) => (
+                                        <div key={idx} className="flex items-center justify-between p-2.5">
+                                            <div className="flex items-center gap-2 min-w-0 flex-1">
+                                                {detail.status === "success" ? (
+                                                    <IconCheck className="size-4 shrink-0 text-green-500" />
+                                                ) : detail.status === "unmatched" ? (
+                                                    <IconFileOff className="size-4 shrink-0 text-amber-500" />
+                                                ) : (
+                                                    <IconX className="size-4 shrink-0 text-destructive" />
+                                                )}
+                                                <span className="truncate font-medium">{detail.filename}</span>
+                                                {detail.controlId && (
+                                                    <Badge variant="outline" className="text-xs font-mono shrink-0">
+                                                        {detail.controlId}
+                                                    </Badge>
+                                                )}
+                                            </div>
+                                            <div className="text-xs shrink-0 pl-4 font-medium">
+                                                {detail.status === "success" ? (
+                                                    <span className="text-green-600 dark:text-green-400">Success</span>
+                                                ) : detail.status === "unmatched" ? (
+                                                    <span className="text-amber-600 dark:text-amber-400" title={detail.error}>Unmatched</span>
+                                                ) : (
+                                                    <span className="text-destructive font-semibold" title={detail.error}>Failed</span>
+                                                )}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <DialogFooter>
+                                <Button onClick={closeTemplateBulkDialog}>
+                                    Close
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    )}
                 </DialogContent>
             </Dialog>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1789,6 +1789,34 @@ class ApiService {
     return response.json();
   }
 
+  async uploadCRCTemplatesBulk(files: File[]): Promise<{
+    success: boolean;
+    message: string;
+    summary: { total: number; success: number; unmatched: number; failed: number };
+    details: Array<{ filename: string; status: 'success' | 'unmatched' | 'failed'; controlId?: string; error?: string }>;
+  }> {
+    const formData = new FormData();
+    files.forEach((file) => {
+      formData.append("files", file);
+    });
+
+    const token = this.getAuthToken();
+    const response = await fetch(`${API_BASE_URL}/crc/templates/bulk-upload`, {
+      method: "POST",
+      headers: {
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: "Bulk upload failed" }));
+      throw new Error(error.error || `HTTP ${response.status}`);
+    }
+
+    return response.json();
+  }
+
   async deleteCRCTemplate(controlId: string): Promise<{ success: boolean; message: string }> {
     return this.request<{ success: boolean; message: string }>(`/crc/templates/${controlId}/template`, {
       method: "DELETE",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk uploading for CRC compliance templates in the admin view, with a dialog for selecting multiple `.doc`, `.docx`, and `.zip` files and showing a per-file results breakdown (success/unmatched/failed) and totals.
* **Bug Fixes**
  * Improved template upload resilience with clearer validation/error responses and safer cleanup of temporary files; also updated legacy cleanup behavior to use consistent path resolution.
* **Chores**
  * Added the required ZIP handling dependency and TypeScript typings to enable bulk ZIP processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->