### PR TITLE
Add e2e coverage for AI Vulnerability Assessment

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -46,19 +46,25 @@ e2e/
 │  ├─ report.page.js          AIMA report
 │  ├─ premium-features.page.js
 │  ├─ wizard.page.js          AI System Profile Wizard
-│  └─ crc.page.js
+│  ├─ crc.page.js
+│  ├─ vulnerability-assessment.page.js  AI Vulnerability Assessment config screen
+│  └─ vulnerability-job.page.js         security-scan job-status screen
 └─ tests/
    ├─ project-lifecycle.spec.js   create a project, then delete it
    ├─ aima-report.spec.js         all 3 answer states, edit + resubmit, nav/notes,
    │                              missing-answers dialog
+   ├─ vulnerability-assessment.spec.js  configure + start a security scan
+   │                                    (stops once the job page is reached —
+   │                                    see TODO in the spec for what's left)
    ├─ premium-feature.spec.js     disabled — CRC + premium suite coverage
    └─ fully-compliant.spec.js     disabled — CRC with full evidence trail
 ```
 
-Only AIMA coverage is active right now. `premium-feature.spec.js` and
-`fully-compliant.spec.js` are commented out in full (uncomment to re-enable);
-their page objects (`premium-features.page.js`, `wizard.page.js`, `crc.page.js`)
-are already in place.
+Only AIMA and vulnerability-assessment (partial) coverage is active right
+now. `premium-feature.spec.js` and `fully-compliant.spec.js` are commented
+out in full (uncomment to re-enable); their page objects
+(`premium-features.page.js`, `wizard.page.js`, `crc.page.js`) are already in
+place.
 
 Add new locators/actions as methods on the relevant page object; write a new
 spec under `tests/`.

--- a/frontend/e2e/pages/premium-features.page.js
+++ b/frontend/e2e/pages/premium-features.page.js
@@ -47,15 +47,16 @@ class PremiumFeaturesPage {
 
   // Completes (and applies) the AI System Profile wizard that gates CRC /
   // premium features for a fresh premium project. Returns true if it ran the
-  // wizard, false if it was already applied.
-  async completeSystemProfileWizard(projectId) {
+  // wizard, false if it was already applied. See WizardPage.complete() re:
+  // systemName — it becomes the project's new display name.
+  async completeSystemProfileWizard(projectId, systemName) {
     await this.goto(projectId);
     await Promise.race([
       this.wizard.configureButton.waitFor({ timeout: 30_000 }).catch(() => {}),
       this.hubHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
     ]);
     if (!(await this.wizard.configureButton.isVisible().catch(() => false))) return false; // already applied
-    await this.wizard.complete();
+    await this.wizard.complete(systemName);
     return true;
   }
 }

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -1,0 +1,60 @@
+// The "AI Vulnerability Assessment" endpoint-configuration screen
+// (/assess/<id>/vulnerability-assessment). Gated only on the account's
+// subscription_status being premium — unlike CRC, it does not require the AI
+// System Profile wizard to have been applied on the project first.
+class VulnerabilityAssessmentPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText(/API Vulnerability Assessment/i).first();
+
+    this.endpointInput = page.locator("#api-endpoint");
+    this.requestTemplateInput = page.locator("#request-template");
+    this.responseKeyInput = page.locator("#response-key-path");
+    this.apiKeyInput = page.locator("#api-key-value");
+    this.apiKeyPlacementSelect = page.locator("#api-key-placement");
+
+    this.runScanButton = page.getByRole("button", { name: /run security scan/i });
+    this.pendingJobsButton = page.getByRole("button", { name: /show all pending jobs/i });
+    this.jobStartError = page.getByText(/failed to start security scan/i);
+
+    // Bottom-of-page "Vulnerability Scan History" panel (ApiHistory
+    // component). Known bug: its Score column always reads "N/A" for
+    // security-scan rows — see ross-server-vuln-assessment-qa memory.
+    this.historyHeading = page.getByText(/vulnerability scan history/i);
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/vulnerability-assessment`, { waitUntil: "domcontentloaded" });
+    await this.endpointInput.waitFor({ timeout: 30_000 });
+  }
+
+  // Fills the endpoint config form. The defaults are a real, working config
+  // (httpbin.org echoes the posted body back under "json", so the response
+  // path actually resolves) — good enough to validate the "does a scan
+  // start" path without needing a real model endpoint.
+  async configure({
+    url = "https://httpbin.org/post",
+    requestTemplate,
+    responseKey = "json.contents[0].parts[0].text",
+  } = {}) {
+    await this.endpointInput.fill(url);
+    if (requestTemplate) {
+      await this.requestTemplateInput.fill(requestTemplate);
+    }
+    await this.responseKeyInput.fill(responseKey);
+  }
+
+  // Submits the form and waits for the redirect to the job-status page.
+  // Returns the jobId parsed from the resulting URL. Job IDs look like
+  // "security-1784018220389-jv4yp0x" — not a UUID, so match word chars.
+  async startScan() {
+    await this.runScanButton.isEnabled({ timeout: 15_000 });
+    await this.runScanButton.click();
+    await this.page.waitForURL(/\/vulnerability-assessment\/job\/[\w-]+/i, { timeout: 30_000 });
+    const match = this.page.url().match(/\/job\/([\w-]+)/i);
+    return match ? match[1] : null;
+  }
+}
+
+module.exports = { VulnerabilityAssessmentPage };

--- a/frontend/e2e/pages/vulnerability-job.page.js
+++ b/frontend/e2e/pages/vulnerability-job.page.js
@@ -1,0 +1,18 @@
+// The security-scan job-status page
+// (/assess/<id>/vulnerability-assessment/job/<jobId>). Polls every 20s and
+// auto-redirects to the report once the job reaches a terminal status
+// (completed/success/partial_success/failed).
+class VulnerabilityJobPage {
+  constructor(page) {
+    this.page = page;
+
+    this.jobIdLabel = page.getByText(/Job ID/i);
+    this.statusBadge = page
+      .getByText(/^(QUEUED|PROCESSING|RUNNING|COLLECTING_RESPONSES|EVALUATING|COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/)
+      .first();
+    this.refreshButton = page.getByRole("button", { name: /refresh now/i });
+    this.viewReportButton = page.getByRole("button", { name: /view report/i });
+  }
+}
+
+module.exports = { VulnerabilityJobPage };

--- a/frontend/e2e/pages/wizard.page.js
+++ b/frontend/e2e/pages/wizard.page.js
@@ -40,15 +40,18 @@ class WizardPage {
   }
 
   // Opens the wizard and fills it with a simple, low-risk profile, then
-  // applies it. Returns once the platform is unlocked.
-  async complete() {
+  // applies it. Returns once the platform is unlocked. Completing the wizard
+  // silently renames the project itself to `systemName` (the "Name of this
+  // AI system" field) — pass a name unique to your test if you need to find
+  // the project again afterwards (e.g. to delete it).
+  async complete(systemName = "Full Premium Feature") {
     await this.configureButton.scrollIntoViewIfNeeded().catch(() => {});
     await this.configureButton.click();
     await this.modalTitle.waitFor();
 
     // Section 1 — Project Setup
     await this.pick("Select scope type", /Single AI System/i);
-    await this.nameInput.fill("Full Premium Feature");
+    await this.nameInput.fill(systemName);
     await this.descInput.fill("E2E full premium feature CRC test system.").catch(() => {});
     await this.pick("Select primary use case", /Customer Service Chatbot/i);
     await this.next();

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -1,0 +1,80 @@
+// AI Vulnerability Assessment: create a project, complete the AI System
+// Profile wizard (vulnerability-assessment is a wizard-gated premium route,
+// same as CRC — see WizardGateProvider / layout.tsx's isPremiumRoute),
+// configure a security-scan endpoint, and start the scan. Covers only up to
+// the scan starting (job status page reachable, status badge visible) — a
+// full run takes ~20 min against even a fast public endpoint, and the
+// pending-jobs list / scan-history score column are known-broken (see
+// ross-server-vuln-assessment-qa memory), so asserting through completion
+// and the history views is left for a follow-up spec.
+//
+// Uses a timestamped project name (like aima-report.spec.js's primary test),
+// not a fixed kept name: completing the AI System Profile wizard silently
+// renames the project to whatever name is typed into the wizard's "Name of
+// this AI system" field, so a fixed name doesn't survive being reused across
+// runs. The wizard is given the same timestamped name for traceability.
+//
+// The project is intentionally left behind, not deleted: as of 2026-07-14
+// the dashboard's delete flow is broken against the live deployment for any
+// never-started project (confirmed on the unrelated, pre-existing
+// project-lifecycle.spec.js too, not just here) — opening a card's menu and
+// clicking "Delete" instead lands on that same card's "Choose Your Path"
+// modal. Stray projects from this spec need manual/API cleanup until that's
+// fixed.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { VulnerabilityAssessmentPage } = require("../pages/vulnerability-assessment.page");
+const { VulnerabilityJobPage } = require("../pages/vulnerability-job.page");
+
+test.setTimeout(3 * 60 * 1000);
+
+test.use({ storageState: STORAGE_STATE });
+
+test.describe("AI Vulnerability Assessment", () => {
+  test("configure an endpoint and start a security scan", async ({ page }) => {
+    const name = `E2E Vulnerability Assessment ${Date.now()}`;
+    const dashboard = new DashboardPage(page);
+    const premiumFeatures = new PremiumFeaturesPage(page);
+    const vulnAssessment = new VulnerabilityAssessmentPage(page);
+    const vulnJob = new VulnerabilityJobPage(page);
+
+    let projectId;
+
+    await test.step("create the project", async () => {
+      await dashboard.createProject(name, "Vulnerability assessment end-to-end test.");
+      projectId = await dashboard.startAssessment(name);
+      expect(projectId).toBeTruthy();
+    });
+
+    await test.step("complete the AI System Profile wizard (unlocks the scan tool)", async () => {
+      await premiumFeatures.completeSystemProfileWizard(projectId, name);
+    });
+
+    await test.step("configure the security-scan endpoint", async () => {
+      await vulnAssessment.goto(projectId);
+      await expect(vulnAssessment.heading).toBeVisible();
+      await vulnAssessment.configure();
+      await expect(vulnAssessment.runScanButton).toBeEnabled({ timeout: 15_000 });
+    });
+
+    await test.step("start the scan and land on the job page", async () => {
+      const jobId = await vulnAssessment.startScan();
+      expect(jobId).toBeTruthy();
+      await expect(vulnJob.jobIdLabel).toBeVisible();
+      await expect(vulnJob.statusBadge).toBeVisible({ timeout: 30_000 });
+
+      await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-job.png", fullPage: true });
+    });
+
+    // TODO (follow-up spec): wait for the job to reach a terminal status,
+    // verify the security scorecard, and cover the known bugs found during
+    // manual QA — "Show all pending jobs" never lists a completed scan
+    // (status filter excludes success/failed/partial_success), the
+    // Vulnerability Scan History table's Score column always reads "N/A",
+    // and PDF export throws on oklch() colors and fails silently. Also add
+    // cleanup (delete the project) once the dashboard's delete flow works
+    // again for never-started projects.
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `vulnerability-assessment.spec.js`, covering the AI Vulnerability
  Assessment flow: create a project → complete the AI System Profile wizard
  (this route is wizard-gated, same as CRC — not obvious from the page's own
  code, which only checks premium status) → configure a security-scan
  endpoint → start the scan and land on the job-status page. Stops there by
  design; a TODO in the spec lists what's left for a follow-up (job
  completion, scorecard assertions, and the pending-jobs-list /
  scan-history-score bugs found during manual QA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for configuring and starting AI Vulnerability Assessment scans.
  * Added validation for scan job pages, including job IDs and status indicators.
  * Project setup workflows can now assign a custom AI system name.

* **Documentation**
  * Updated E2E coverage documentation to include vulnerability-assessment flows and current active suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->