### PR TITLE
Complete AI Vulnerability Assessment and CRC e2e coverage

### DIFF
--- a/frontend/e2e/.env.e2e.example
+++ b/frontend/e2e/.env.e2e.example
@@ -1,7 +1,13 @@
 # Copy to e2e/.env.e2e and fill in. Never commit real credentials.
 
-# App under test (defaults to the live deployment if unset)
+# App under test.
 E2E_BASE_URL=https://ross-server-w14l.vercel.app
+
+# Backend origin for direct API calls that bypass the UI (e.g. project
+# cleanup DELETEs). Must be the backend E2E_BASE_URL's frontend actually
+# talks to — if you point E2E_BASE_URL at a different environment, update
+# this to match.
+E2E_API_URL=https://ross-server-theta.vercel.app
 
 # A dedicated TEST account. The suite creates & deletes throwaway projects,
 # so do NOT point this at a real customer account.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -46,19 +46,25 @@ e2e/
 │  ├─ report.page.js          AIMA report
 │  ├─ premium-features.page.js
 │  ├─ wizard.page.js          AI System Profile Wizard
-│  └─ crc.page.js
+│  ├─ crc.page.js
+│  ├─ vulnerability-assessment.page.js  AI Vulnerability Assessment config screen
+│  └─ vulnerability-job.page.js         security-scan job-status screen
 └─ tests/
    ├─ project-lifecycle.spec.js   create a project, then delete it
    ├─ aima-report.spec.js         all 3 answer states, edit + resubmit, nav/notes,
    │                              missing-answers dialog
+   ├─ vulnerability-assessment.spec.js  configure + start a security scan
+   │                                    (stops once the job page is reached —
+   │                                    see TODO in the spec for what's left)
    ├─ premium-feature.spec.js     disabled — CRC + premium suite coverage
    └─ fully-compliant.spec.js     disabled — CRC with full evidence trail
 ```
 
-Only AIMA coverage is active right now. `premium-feature.spec.js` and
-`fully-compliant.spec.js` are commented out in full (uncomment to re-enable);
-their page objects (`premium-features.page.js`, `wizard.page.js`, `crc.page.js`)
-are already in place.
+Only AIMA and vulnerability-assessment (partial) coverage is active right
+now. `premium-feature.spec.js` and `fully-compliant.spec.js` are commented
+out in full (uncomment to re-enable); their page objects
+(`premium-features.page.js`, `wizard.page.js`, `crc.page.js`) are already in
+place.
 
 Add new locators/actions as methods on the relevant page object; write a new
 spec under `tests/`.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -40,7 +40,11 @@ e2e/
 ├─ constants.js               storage-state path, creds, answer options
 ├─ auth.setup.js              logs in once, saves signed-in state
 ├─ pages/                     page objects, one class per screen  ← extend here
-│  ├─ auth.page.js
+│  ├─ auth.page.js                      login + signup form
+│  ├─ forgot-password.page.js
+│  ├─ reset-password.page.js
+│  ├─ verify-email.page.js              link-based email verification
+│  ├─ verify-otp.page.js                6-digit code verification
 │  ├─ dashboard.page.js
 │  ├─ assessment.page.js      AIMA question flow
 │  ├─ report.page.js          AIMA report
@@ -51,7 +55,13 @@ e2e/
 │  ├─ vulnerability-assessment.page.js  AI Vulnerability Assessment config screen
 │  ├─ vulnerability-job.page.js         security-scan job-status screen
 │  ├─ vulnerability-pending-jobs.page.js  security-scan pending-jobs list
-│  └─ vulnerability-report.page.js      security-scan report/scorecard
+│  ├─ vulnerability-report.page.js      security-scan report/scorecard
+│  ├─ project-settings.page.js          per-project "Project Details" edit form
+│  ├─ team.page.js                      per-project team/invite management
+│  ├─ invite.page.js                    /invite/accept landing page
+│  ├─ inventory.page.js                 AI Component Inventory
+│  ├─ account-settings.page.js          global /settings (notifications, deleted projects)
+│  └─ manage-subscription.page.js       /manage-subscription (read-only)
 └─ tests/
    ├─ project-lifecycle.spec.js   create a project, then delete it
    ├─ aima-report.spec.js         all 3 answer states, edit + resubmit, nav/notes,
@@ -62,18 +72,46 @@ e2e/
    │                              Wins empty-state check
    ├─ crc-pdf-export.spec.js      standalone CRC dashboard PDF re-check (skips
    │                              unless CRC_PDF_PROJECT_ID is set)
+   ├─ crc-dashboard.spec.js       wizard-gate on /crc/dashboard itself, Framework
+   │                              Readiness cards + Evidence Progress rendering
    ├─ vulnerability-assessment.spec.js  full security-scan lifecycle: configure,
    │                                    start, wait for a terminal status,
    │                                    verify the scorecard, PDF export,
    │                                    pending-jobs list, scan history
+   ├─ inventory.spec.js           add a component (OpenAI defaults + No Data
+   │                              Processing) → Low-risk row → delete
+   ├─ project-settings.spec.js    edit project name/description, persists on reload
+   ├─ team-invite.spec.js         send + revoke a project invite; /invite/accept
+   │                              token-error states
+   ├─ account-settings.spec.js    notification-preference toggle persistence;
+   │                              deleted-project recovery (dashboard delete →
+   │                              Settings > Deleted Projects → restore)
+   ├─ manage-subscription.spec.js  read-only smoke check (no billing actions —
+   │                               see the page object for why)
+   ├─ auth-flows.spec.js          signup validation, wrong-password login,
+   │                              forgot/reset-password and verify-email/otp
+   │                              error paths (no real account/reset/verify
+   │                              completed — needs a real mailbox this suite
+   │                              doesn't have)
    ├─ premium-feature.spec.js     disabled — CRC + premium suite coverage
    └─ fully-compliant.spec.js     disabled — CRC with full evidence trail
 ```
 
-AIMA, CRC, and vulnerability-assessment coverage are all active.
+AIMA, CRC, vulnerability-assessment, inventory, project-settings, team/invite,
+account-settings, manage-subscription, and auth-flows coverage are all active.
 `premium-feature.spec.js` and `fully-compliant.spec.js` are commented out in
 full (uncomment to re-enable); their page objects (`premium-features.page.js`,
 `wizard.page.js`, `crc.page.js`) are already in place.
+
+Deliberately out of scope for this pass, and left as-is rather than half-done:
+- Full invite-accept and signup/verify-email/reset-password *happy paths* —
+  each needs a second real mailbox to read the email this suite would trigger
+  sending; only every page's error/negative paths are covered instead (see
+  `team-invite.spec.js` and `auth-flows.spec.js`).
+- Any `/manage-subscription` action (Upgrade/Cancel) — real Stripe billing
+  against the shared test account's actual subscription.
+- Bias & Fairness Testing (`/assess/<id>/fairness-bias/*`) — explicitly out of
+  scope; not attempted here.
 
 Add new locators/actions as methods on the relevant page object; write a new
 spec under `tests/`.
@@ -83,9 +121,11 @@ spec under `tests/`.
 - Answering every question "Yes" yields 3.00; "Partially" yields 1.50; "No"
   yields a score below the app's Level 1 threshold, so the report shows a
   "progress to Level 1 %" figure instead of a plain score.
-- Download verification is disabled across the specs — the "Download Report"
-  button is gated behind an AI-insights job that can take a while. Report
-  content (score, questions-evaluated count, domain breakdown) is checked
-  instead; a dedicated download check will be added separately.
+- Download verification is disabled only for the AIMA report — its "Download
+  Report" button is gated behind an AI-insights job that can take a while, so
+  report content (score, questions-evaluated count, domain breakdown) is
+  checked instead. CRC (`crc-full.spec.js`) and vulnerability-assessment
+  (`vulnerability-assessment.spec.js`) both verify their PDF exports actually
+  download.
 - Seeding specs create and delete throwaway projects — use a dedicated test
   account, never a real customer's.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -46,25 +46,34 @@ e2e/
 │  ├─ report.page.js          AIMA report
 │  ├─ premium-features.page.js
 │  ├─ wizard.page.js          AI System Profile Wizard
-│  ├─ crc.page.js
+│  ├─ crc.page.js                       CRC assessment question flow
+│  ├─ crc-dashboard.page.js             CRC Readiness Dashboard
 │  ├─ vulnerability-assessment.page.js  AI Vulnerability Assessment config screen
-│  └─ vulnerability-job.page.js         security-scan job-status screen
+│  ├─ vulnerability-job.page.js         security-scan job-status screen
+│  ├─ vulnerability-pending-jobs.page.js  security-scan pending-jobs list
+│  └─ vulnerability-report.page.js      security-scan report/scorecard
 └─ tests/
    ├─ project-lifecycle.spec.js   create a project, then delete it
    ├─ aima-report.spec.js         all 3 answer states, edit + resubmit, nav/notes,
    │                              missing-answers dialog
-   ├─ vulnerability-assessment.spec.js  configure + start a security scan
-   │                                    (stops once the job page is reached —
-   │                                    see TODO in the spec for what's left)
+   ├─ crc-full.spec.js            full CRC lifecycle: 100%-Yes scoring + PDF
+   │                              export, mixed NA/Yes/No scoring, submit-blocked
+   │                              guard, evidence tracker + URL blocklist, Quick
+   │                              Wins empty-state check
+   ├─ crc-pdf-export.spec.js      standalone CRC dashboard PDF re-check (skips
+   │                              unless CRC_PDF_PROJECT_ID is set)
+   ├─ vulnerability-assessment.spec.js  full security-scan lifecycle: configure,
+   │                                    start, wait for a terminal status,
+   │                                    verify the scorecard, PDF export,
+   │                                    pending-jobs list, scan history
    ├─ premium-feature.spec.js     disabled — CRC + premium suite coverage
    └─ fully-compliant.spec.js     disabled — CRC with full evidence trail
 ```
 
-Only AIMA and vulnerability-assessment (partial) coverage is active right
-now. `premium-feature.spec.js` and `fully-compliant.spec.js` are commented
-out in full (uncomment to re-enable); their page objects
-(`premium-features.page.js`, `wizard.page.js`, `crc.page.js`) are already in
-place.
+AIMA, CRC, and vulnerability-assessment coverage are all active.
+`premium-feature.spec.js` and `fully-compliant.spec.js` are commented out in
+full (uncomment to re-enable); their page objects (`premium-features.page.js`,
+`wizard.page.js`, `crc.page.js`) are already in place.
 
 Add new locators/actions as methods on the relevant page object; write a new
 spec under `tests/`.

--- a/frontend/e2e/constants.js
+++ b/frontend/e2e/constants.js
@@ -8,6 +8,12 @@ module.exports = {
   EMAIL: process.env.E2E_EMAIL || "",
   PASSWORD: process.env.E2E_PASSWORD || "",
 
+  // Backend origin for direct API calls that bypass the UI (e.g. project
+  // cleanup — see the dashboard delete-flow bug noted in
+  // vulnerability-assessment.spec.js). Defaults to the live deployment,
+  // same convention as E2E_BASE_URL above.
+  API_BASE_URL: process.env.E2E_API_URL || "https://ross-server-theta.vercel.app",
+
   // AIMA answer options, exactly as rendered in QuestionView.
   // (value scale, for reference: No = 0, Partially = 1.5, Yes = 3)
   AIMA_ANSWERS: ["No", "Partially", "Yes"],

--- a/frontend/e2e/constants.js
+++ b/frontend/e2e/constants.js
@@ -8,11 +8,20 @@ module.exports = {
   EMAIL: process.env.E2E_EMAIL || "",
   PASSWORD: process.env.E2E_PASSWORD || "",
 
+  // App under test — see e2e/.env.e2e.example. No hardcoded fallback here on
+  // purpose: playwright.config.js is the only other place BASE_URL matters,
+  // and it reads this same env var directly, so there's one source of truth
+  // (the env file) rather than a literal duplicated across two JS files.
+  BASE_URL: process.env.E2E_BASE_URL || "",
+
   // Backend origin for direct API calls that bypass the UI (e.g. project
-  // cleanup — see the dashboard delete-flow bug noted in
-  // vulnerability-assessment.spec.js). Defaults to the live deployment,
-  // same convention as E2E_BASE_URL above.
-  API_BASE_URL: process.env.E2E_API_URL || "https://ross-server-theta.vercel.app",
+  // cleanup DELETEs — see the dashboard delete-flow bug noted in
+  // vulnerability-assessment.spec.js). No hardcoded fallback: this backs a
+  // destructive call, so it must come from the same env file as
+  // E2E_BASE_URL (see .env.e2e.example) rather than risk silently pointing
+  // at a default backend that doesn't match wherever E2E_BASE_URL actually
+  // points.
+  API_BASE_URL: process.env.E2E_API_URL || "",
 
   // AIMA answer options, exactly as rendered in QuestionView.
   // (value scale, for reference: No = 0, Partially = 1.5, Yes = 3)

--- a/frontend/e2e/pages/account-settings.page.js
+++ b/frontend/e2e/pages/account-settings.page.js
@@ -1,0 +1,40 @@
+class AccountSettingsPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText(/account settings/i).first();
+
+    // Notifications — each Switch's id matches its Label's htmlFor exactly
+    // (weekly_digest / critical_alerts / vendor_reassessment), so getByLabel
+    // resolves the underlying Radix switch button directly.
+    this.weeklyDigestSwitch = page.getByLabel(/weekly digest/i);
+    this.criticalAlertsSwitch = page.getByLabel(/critical risk alerts/i);
+    this.vendorReassessmentSwitch = page.getByLabel(/vendor reassessment reminders/i);
+
+    this.deletedProjectsHeading = page.getByText(/deleted projects/i).first();
+    this.noDeletedProjectsText = page.getByText(/no deleted projects/i);
+  }
+
+  async goto() {
+    await this.page.goto("/settings", { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  // The wrapping <div> holds an <h4>{name}</h4> plus a "Restore" button —
+  // match on text rather than a heading role to keep this independent of
+  // how h4 gets mapped to accessibility roles.
+  deletedProjectRestoreButton(name) {
+    return this.page
+      .locator("div")
+      .filter({ hasText: name })
+      .filter({ has: this.page.getByRole("button", { name: /restore/i }) })
+      .last()
+      .getByRole("button", { name: /restore/i });
+  }
+
+  async restoreDeletedProject(name) {
+    await this.deletedProjectRestoreButton(name).click();
+  }
+}
+
+module.exports = { AccountSettingsPage };

--- a/frontend/e2e/pages/account-settings.page.js
+++ b/frontend/e2e/pages/account-settings.page.js
@@ -2,17 +2,19 @@ class AccountSettingsPage {
   constructor(page) {
     this.page = page;
 
-    this.heading = page.getByText(/account settings/i).first();
+    this.heading = page.getByText("Account Settings", { exact: true }).first();
 
     // Notifications — each Switch's id matches its Label's htmlFor exactly
     // (weekly_digest / critical_alerts / vendor_reassessment), so getByLabel
     // resolves the underlying Radix switch button directly.
-    this.weeklyDigestSwitch = page.getByLabel(/weekly digest/i);
-    this.criticalAlertsSwitch = page.getByLabel(/critical risk alerts/i);
-    this.vendorReassessmentSwitch = page.getByLabel(/vendor reassessment reminders/i);
+    this.weeklyDigestSwitch = page.getByLabel("Weekly Digest", { exact: true });
+    this.criticalAlertsSwitch = page.getByLabel("Critical Risk Alerts", { exact: true });
+    this.vendorReassessmentSwitch = page.getByLabel("Vendor Reassessment Reminders", { exact: true });
 
-    this.deletedProjectsHeading = page.getByText(/deleted projects/i).first();
-    this.noDeletedProjectsText = page.getByText(/no deleted projects/i);
+    this.deletedProjectsHeading = page.getByText("Deleted Projects", { exact: true }).first();
+    // Start of a longer sentence ("No deleted projects. Projects you delete
+    // will be kept here for 30 days...") — substring match, not exact.
+    this.noDeletedProjectsText = page.getByText("No deleted projects");
   }
 
   async goto() {
@@ -22,14 +24,17 @@ class AccountSettingsPage {
 
   // The wrapping <div> holds an <h4>{name}</h4> plus a "Restore" button —
   // match on text rather than a heading role to keep this independent of
-  // how h4 gets mapped to accessibility roles.
+  // how h4 gets mapped to accessibility roles. `name` itself is caller-
+  // supplied dynamic data (a project name), not a UI-copy regex, so it's
+  // left as a plain string substring match here — this isn't the kind of
+  // locator that has a fixed accessible name to pin to.
   deletedProjectRestoreButton(name) {
     return this.page
       .locator("div")
       .filter({ hasText: name })
-      .filter({ has: this.page.getByRole("button", { name: /restore/i }) })
+      .filter({ has: this.page.getByRole("button", { name: "Restore", exact: true }) })
       .last()
-      .getByRole("button", { name: /restore/i });
+      .getByRole("button", { name: "Restore", exact: true });
   }
 
   async restoreDeletedProject(name) {

--- a/frontend/e2e/pages/assessment.page.js
+++ b/frontend/e2e/pages/assessment.page.js
@@ -5,18 +5,28 @@ class AssessmentPage {
   constructor(page) {
     this.page = page;
 
+    // "Question {n} of {total}" is genuinely dynamic (live counter) —
+    // can't drop the regex.
     this.questionCounter = page.getByText(/Question \d+ of \d+/).first();
-    this.nextButton = page.getByRole("button", { name: "Next" });
-    this.previousButton = page.getByRole("button", { name: "Previous" });
-    this.submitButton = page.getByRole("button", { name: /submit project/i }).first();
-    // Once a project is already completed, the same button relabels to this.
-    this.resubmitButton = page.getByRole("button", { name: /resubmit changes/i }).first();
+    this.nextButton = page.getByRole("button", { name: "Next", exact: true });
+    this.previousButton = page.getByRole("button", { name: "Previous", exact: true });
+    // QuestionView.tsx: `isCompleted ? 'Resubmit Changes' : 'Submit Project'`
+    // — two mutually-exclusive fixed strings.
+    this.submitButton = page.getByRole("button", { name: "Submit Project", exact: true }).first();
+    this.resubmitButton = page.getByRole("button", { name: "Resubmit Changes", exact: true }).first();
 
-    this.missingDialog = page.getByRole("dialog").filter({ hasText: /unanswered|missing/i });
-    this.missingDialogGoToFirst = this.missingDialog.getByRole("button", { name: /go to first unanswered/i });
+    // "<N> unanswered question(s)" is the dialog's actual <DialogTitle>, so
+    // it's the accessible name Radix exposes via aria-labelledby — matching
+    // on `name` targets that title specifically instead of scanning the
+    // whole dialog body (which also lists the unanswered questions' own text
+    // and could coincidentally contain "missing"/"unanswered").
+    this.missingDialog = page.getByRole("dialog", { name: /unanswered question/i });
+    this.missingDialogGoToFirst = this.missingDialog.getByRole("button", { name: "Go to first unanswered", exact: true });
 
-    this.notesTextarea = page.getByPlaceholder(/add your notes/i);
-    this.savingIndicator = page.getByText(/saving\.\.\./i);
+    // Full placeholder is "Add your notes, reminders, or thoughts about this
+    // question..." — substring match, not exact.
+    this.notesTextarea = page.getByPlaceholder("Add your notes");
+    this.savingIndicator = page.getByText("Saving...", { exact: true });
   }
 
   answerOption(label) {

--- a/frontend/e2e/pages/auth.page.js
+++ b/frontend/e2e/pages/auth.page.js
@@ -1,16 +1,22 @@
 class AuthPage {
   constructor(page) {
     this.page = page;
-    this.emailInput = page.getByRole("textbox", { name: /email/i }).or(page.locator('input[type="email"]')).first();
+    // <Label htmlFor="email">Email address</Label> associates cleanly with
+    // the input, so its accessible name is exactly "Email address" — no
+    // fallback locator needed.
+    this.emailInput = page.getByRole("textbox", { name: "Email address", exact: true });
     this.passwordInput = page.locator('input[type="password"]').first();
-    this.signInButton = page.getByRole("button", { name: /sign in/i });
+    // Button text is "Sign in"/"Create account" (lowercase, per
+    // frontend/src/app/auth/page.tsx) — verified against source since the
+    // old case-insensitive regex was masking the real casing.
+    this.signInButton = page.getByRole("button", { name: "Sign in", exact: true });
 
     // Signup-only fields (isLogin=false). #password/#confirmPassword ids are
     // shared with the login form's single password field, so scope by id.
     this.nameInput = page.locator("#name");
     this.signupPasswordInput = page.locator("#password");
     this.confirmPasswordInput = page.locator("#confirmPassword");
-    this.createAccountButton = page.getByRole("button", { name: /create account/i });
+    this.createAccountButton = page.getByRole("button", { name: "Create account", exact: true });
   }
 
   // Matches the inline error banner rendered from AuthPage's `error` state

--- a/frontend/e2e/pages/auth.page.js
+++ b/frontend/e2e/pages/auth.page.js
@@ -4,6 +4,24 @@ class AuthPage {
     this.emailInput = page.getByRole("textbox", { name: /email/i }).or(page.locator('input[type="email"]')).first();
     this.passwordInput = page.locator('input[type="password"]').first();
     this.signInButton = page.getByRole("button", { name: /sign in/i });
+
+    // Signup-only fields (isLogin=false). #password/#confirmPassword ids are
+    // shared with the login form's single password field, so scope by id.
+    this.nameInput = page.locator("#name");
+    this.signupPasswordInput = page.locator("#password");
+    this.confirmPasswordInput = page.locator("#confirmPassword");
+    this.createAccountButton = page.getByRole("button", { name: /create account/i });
+  }
+
+  // Matches the inline error banner rendered from AuthPage's `error` state
+  // (frontend/src/app/auth/page.tsx) — same markup for both the login and
+  // signup forms, distinguished only by message text.
+  errorText(pattern) {
+    return this.page.getByText(pattern);
+  }
+
+  async goto(isLogin) {
+    await this.page.goto(`/auth?isLogin=${isLogin}`, { waitUntil: "domcontentloaded" });
   }
 
   async login(email, password) {
@@ -12,6 +30,25 @@ class AuthPage {
     await this.passwordInput.fill(password);
     await this.signInButton.click();
     await this.page.waitForURL("**/dashboard");
+  }
+
+  // Attempts login with the given credentials and stays on /auth (doesn't
+  // wait for the dashboard redirect) — for negative-path assertions.
+  async attemptLogin(email, password) {
+    await this.goto(true);
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.signInButton.click();
+  }
+
+  // Note for callers: the name field's pattern (^[^0-9]*$) rejects any
+  // digit, e.g. "E2E" fails it (that "2" is a digit) — use a digit-free name.
+  async fillSignupForm({ name, email, password, confirmPassword }) {
+    await this.goto(false);
+    if (name !== undefined) await this.nameInput.fill(name);
+    await this.emailInput.fill(email);
+    await this.signupPasswordInput.fill(password);
+    await this.confirmPasswordInput.fill(confirmPassword);
   }
 }
 

--- a/frontend/e2e/pages/crc-dashboard.page.js
+++ b/frontend/e2e/pages/crc-dashboard.page.js
@@ -18,16 +18,9 @@ class CrcDashboardPage {
     await this.page.goto(`/assess/${projectId}/crc/dashboard`, { waitUntil: "domcontentloaded" });
     // Wait for whichever stable state the 4-call load waterfall settles into
     // — a scored tier badge, or the empty state on a zero-answer project —
-    // instead of a fixed sleep.
-    // No .catch() here on purpose: if neither state ever appears, the
-    // waitFor() should reject and surface a real timeout error at the call
-    // site, rather than Promise.race silently resolving once both swallowed
-    // timeouts settle (which would let the caller proceed against a page
-    // that never actually loaded).
-    await Promise.race([
-      this.tierBadge.waitFor({ timeout: 30_000 }),
-      this.noAssessmentData.waitFor({ timeout: 30_000 }),
-    ]);
+    // instead of a fixed sleep. .or() rejects if neither appears within the
+    // timeout, so a real load failure still surfaces at the call site.
+    await this.tierBadge.or(this.noAssessmentData).waitFor({ timeout: 30_000 });
   }
 }
 

--- a/frontend/e2e/pages/crc-dashboard.page.js
+++ b/frontend/e2e/pages/crc-dashboard.page.js
@@ -16,7 +16,13 @@ class CrcDashboardPage {
 
   async goto(projectId) {
     await this.page.goto(`/assess/${projectId}/crc/dashboard`, { waitUntil: "domcontentloaded" });
-    await this.page.waitForTimeout(1500); // let the 4-call load waterfall settle
+    // Wait for whichever stable state the 4-call load waterfall settles into
+    // — a scored tier badge, or the empty state on a zero-answer project —
+    // instead of a fixed sleep.
+    await Promise.race([
+      this.tierBadge.waitFor({ timeout: 30_000 }).catch(() => {}),
+      this.noAssessmentData.waitFor({ timeout: 30_000 }).catch(() => {}),
+    ]);
   }
 }
 

--- a/frontend/e2e/pages/crc-dashboard.page.js
+++ b/frontend/e2e/pages/crc-dashboard.page.js
@@ -19,9 +19,14 @@ class CrcDashboardPage {
     // Wait for whichever stable state the 4-call load waterfall settles into
     // — a scored tier badge, or the empty state on a zero-answer project —
     // instead of a fixed sleep.
+    // No .catch() here on purpose: if neither state ever appears, the
+    // waitFor() should reject and surface a real timeout error at the call
+    // site, rather than Promise.race silently resolving once both swallowed
+    // timeouts settle (which would let the caller proceed against a page
+    // that never actually loaded).
     await Promise.race([
-      this.tierBadge.waitFor({ timeout: 30_000 }).catch(() => {}),
-      this.noAssessmentData.waitFor({ timeout: 30_000 }).catch(() => {}),
+      this.tierBadge.waitFor({ timeout: 30_000 }),
+      this.noAssessmentData.waitFor({ timeout: 30_000 }),
     ]);
   }
 }

--- a/frontend/e2e/pages/crc-dashboard.page.js
+++ b/frontend/e2e/pages/crc-dashboard.page.js
@@ -2,16 +2,24 @@ class CrcDashboardPage {
   constructor(page) {
     this.page = page;
 
-    this.noAssessmentData = page.getByText(/no assessment data yet/i);
-    this.quickWinsHeading = page.getByText(/quick wins/i).first();
-    // "Ready" / "Partially Ready" / "Not Ready" tier badge next to the big
-    // circular readiness %.
+    this.noAssessmentData = page.getByText("No assessment data yet", { exact: true });
+    // QuickWinsWidget's heading text varies by state ("⚡ Quick Wins:
+    // Recommended for this week" active vs "Complete your AI System Profile
+    // to activate Quick Wins" gated) — "Quick Wins" is the only substring
+    // common to both, so this can't be an exact match.
+    this.quickWinsHeading = page.getByText("Quick Wins").first();
+    // "Ready" / "Partially Ready" / "Not Ready" / "Insufficient Data" tier
+    // badge next to the big circular readiness % (getReadinessTier() in
+    // crc/dashboard/page.tsx) — four mutually-exclusive fixed labels.
     this.tierBadge = page
-      .getByText(/^(ready|partially ready|not ready|insufficient data)$/i)
+      .getByText("Ready", { exact: true })
+      .or(page.getByText("Partially Ready", { exact: true }))
+      .or(page.getByText("Not Ready", { exact: true }))
+      .or(page.getByText("Insufficient Data", { exact: true }))
       .first();
-    this.overallReadinessLabel = page.getByText(/overall readiness/i).first();
-    this.exportFullButton = page.getByRole("button", { name: /download full pdf/i }).first();
-    this.exportSummaryButton = page.getByRole("button", { name: /download summary/i }).first();
+    this.overallReadinessLabel = page.getByText("Overall Readiness", { exact: true }).first();
+    this.exportFullButton = page.getByRole("button", { name: "Download Full PDF", exact: true }).first();
+    this.exportSummaryButton = page.getByRole("button", { name: "Download Summary", exact: true }).first();
   }
 
   async goto(projectId) {

--- a/frontend/e2e/pages/crc-dashboard.page.js
+++ b/frontend/e2e/pages/crc-dashboard.page.js
@@ -1,0 +1,23 @@
+class CrcDashboardPage {
+  constructor(page) {
+    this.page = page;
+
+    this.noAssessmentData = page.getByText(/no assessment data yet/i);
+    this.quickWinsHeading = page.getByText(/quick wins/i).first();
+    // "Ready" / "Partially Ready" / "Not Ready" tier badge next to the big
+    // circular readiness %.
+    this.tierBadge = page
+      .getByText(/^(ready|partially ready|not ready|insufficient data)$/i)
+      .first();
+    this.overallReadinessLabel = page.getByText(/overall readiness/i).first();
+    this.exportFullButton = page.getByRole("button", { name: /download full pdf/i }).first();
+    this.exportSummaryButton = page.getByRole("button", { name: /download summary/i }).first();
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/crc/dashboard`, { waitUntil: "domcontentloaded" });
+    await this.page.waitForTimeout(1500); // let the 4-call load waterfall settle
+  }
+}
+
+module.exports = { CrcDashboardPage };

--- a/frontend/e2e/pages/crc.page.js
+++ b/frontend/e2e/pages/crc.page.js
@@ -18,9 +18,21 @@ class CrcPage {
     this.evidenceUrlInput = page.getByLabel(/evidence url/i);
     this.auditReadyCheckbox = page.getByLabel(/audit-ready confirmation/i);
 
+    // Sonner toasts (see frontend/src/lib/toast.ts) render their message as
+    // plain text, so a substring match against the backend's exact error
+    // copy is enough to find them.
+    this.blockedEvidenceUrlToast = page.getByText(/does not appear to be a real evidence document/i);
+    this.evidenceUrlSavedToast = page.getByText(/evidence url saved/i);
+
     this.reportSummaryHeading = page.getByText(/compliance readiness summary/i);
     this.reportOverallReadiness = page.getByText(/overall compliance readiness/i);
     this.reportByCategory = page.getByText(/by category/i);
+    // "Strong"/"Moderate"/"Developing"/"Needs Attention" maturity badge on
+    // /score-report-crc, next to the overall %.
+    this.reportMaturityLabel = page
+      .getByText(/^(strong|moderate|developing|needs attention)$/i)
+      .first();
+    this.submitBlockedReason = page.getByTitle(/answer all controls/i);
   }
 
   answerOption(label) {
@@ -45,11 +57,10 @@ class CrcPage {
     await this.page.waitForTimeout(300);
   }
 
-  // Answers every control with `label`, walking via "Next", then submits.
-  // Lands on /score-report-crc. Requires the wizard to have been applied
-  // first. Pass withEvidence to also fully populate each control's evidence
-  // tracker before moving on.
-  async answerAllAndSubmit(projectId, label = "Yes", withEvidence = false) {
+  // Navigates to the first unanswered control, going through the welcome
+  // page's "Start"/"Continue" CTA if present. Shared by answerAllAndSubmit
+  // and any test that only needs a control or two, not a full walk.
+  async gotoAssessment(projectId) {
     await this.page.goto(`/assess/${projectId}/crc/welcome`, { waitUntil: "domcontentloaded" });
     const started = await this.welcomeStartLink
       .waitFor({ timeout: 30_000 })
@@ -59,10 +70,22 @@ class CrcPage {
     else await this.page.goto(`/assess/${projectId}/crc`, { waitUntil: "domcontentloaded" });
 
     await expect(this.counter).toBeVisible({ timeout: 30_000 });
+  }
+
+  // Answers every control, walking via "Next", then submits. Lands on
+  // /score-report-crc. Requires the wizard to have been applied first.
+  // `labelOrFn` is either a fixed answer label ("Yes"/"No"/"Partially"/"NA"/
+  // "Not Sure") applied to every control, or a function (index, total) =>
+  // label for a mixed pattern (index is 0-based). Pass withEvidence to also
+  // fully populate each control's evidence tracker before moving on.
+  async answerAllAndSubmit(projectId, labelOrFn = "Yes", withEvidence = false) {
+    await this.gotoAssessment(projectId);
 
     for (let i = 0; i < 300; i++) {
       const text = await this.counter.innerText();
       const match = text.match(/Control (\d+) of (\d+)/);
+      const total = match ? Number(match[2]) : null;
+      const label = typeof labelOrFn === "function" ? labelOrFn(i, total) : labelOrFn;
 
       await this.answerOption(label).click();
       await this.page.waitForTimeout(400); // let the answer persist

--- a/frontend/e2e/pages/crc.page.js
+++ b/frontend/e2e/pages/crc.page.js
@@ -85,7 +85,12 @@ class CrcPage {
       const text = await this.counter.innerText();
       const match = text.match(/Control (\d+) of (\d+)/);
       const total = match ? Number(match[2]) : null;
-      const label = typeof labelOrFn === "function" ? labelOrFn(i, total) : labelOrFn;
+      // Derived from the displayed "Control N of M", not the loop variable:
+      // gotoAssessment() can resume at the first unanswered control (not
+      // necessarily #1), so a mixed pattern keyed on the loop index would be
+      // applied to the wrong controls after a resume.
+      const index = match ? Number(match[1]) - 1 : i;
+      const label = typeof labelOrFn === "function" ? labelOrFn(index, total) : labelOrFn;
 
       await this.answerOption(label).click();
       await this.page.waitForTimeout(400); // let the answer persist

--- a/frontend/e2e/pages/crc.page.js
+++ b/frontend/e2e/pages/crc.page.js
@@ -8,31 +8,49 @@ class CrcPage {
   constructor(page) {
     this.page = page;
 
-    this.welcomeStartLink = page.getByRole("link", { name: /start crc assessment|continue to the crc assessment/i });
+    // crc/welcome/page.tsx: `hasProgress ? "Continue to the CRC assessment"
+    // : "Start CRC assessment"` — two mutually-exclusive fixed strings
+    // (lowercase "assessment", verified against source).
+    this.welcomeStartLink = page
+      .getByRole("link", { name: "Start CRC assessment", exact: true })
+      .or(page.getByRole("link", { name: "Continue to the CRC assessment", exact: true }));
 
+    // "Control N of M" is genuinely dynamic (live counter), so this is the
+    // one locator in this file that can't drop the regex.
     this.counter = page.getByText(/Control \d+ of \d+/).first();
-    this.nextButton = page.getByRole("button", { name: /^next$/i });
-    this.submitButton = page.getByRole("button", { name: /submit assessment/i });
+    this.nextButton = page.getByRole("button", { name: "Next", exact: true });
+    this.submitButton = page.getByRole("button", { name: "Submit Assessment", exact: true });
 
-    this.evidenceStatusSelect = page.getByLabel(/select status/i);
-    this.evidenceUrlInput = page.getByLabel(/evidence url/i);
-    this.auditReadyCheckbox = page.getByLabel(/audit-ready confirmation/i);
+    this.evidenceStatusSelect = page.getByLabel("Select Status", { exact: true });
+    // Full label text is "Evidence URL (HTTPS required)" — substring match,
+    // not exact.
+    this.evidenceUrlInput = page.getByLabel("Evidence URL");
+    // Full label text is "🔒 Audit-ready confirmation" — substring match to
+    // avoid having to encode the emoji prefix exactly.
+    this.auditReadyCheckbox = page.getByLabel("Audit-ready confirmation");
 
     // Sonner toasts (see frontend/src/lib/toast.ts) render their message as
-    // plain text, so a substring match against the backend's exact error
-    // copy is enough to find them.
-    this.blockedEvidenceUrlToast = page.getByText(/does not appear to be a real evidence document/i);
-    this.evidenceUrlSavedToast = page.getByText(/evidence url saved/i);
+    // plain text; Playwright's getByText is already a case-insensitive
+    // substring match on a plain string, so no regex is needed to match
+    // against the backend's longer exact error copy.
+    this.blockedEvidenceUrlToast = page.getByText("does not appear to be a real evidence document");
+    this.evidenceUrlSavedToast = page.getByText("Evidence URL saved", { exact: true });
 
-    this.reportSummaryHeading = page.getByText(/compliance readiness summary/i);
-    this.reportOverallReadiness = page.getByText(/overall compliance readiness/i);
-    this.reportByCategory = page.getByText(/by category/i);
+    this.reportSummaryHeading = page.getByText("Compliance Readiness Summary", { exact: true });
+    this.reportOverallReadiness = page.getByText("Overall compliance readiness", { exact: true });
+    this.reportByCategory = page.getByText("By Category", { exact: true });
     // "Strong"/"Moderate"/"Developing"/"Needs Attention" maturity badge on
-    // /score-report-crc, next to the overall %.
+    // /score-report-crc, next to the overall % (getMaturityTier()'s labels).
     this.reportMaturityLabel = page
-      .getByText(/^(strong|moderate|developing|needs attention)$/i)
+      .getByText("Strong", { exact: true })
+      .or(page.getByText("Moderate", { exact: true }))
+      .or(page.getByText("Developing", { exact: true }))
+      .or(page.getByText("Needs Attention", { exact: true }))
       .first();
-    this.submitBlockedReason = page.getByTitle(/answer all controls/i);
+    // title attribute interpolates live counts ("Answer all controls (3/138)
+    // before submitting"), so this stays a substring match, just without the
+    // regex wrapper.
+    this.submitBlockedReason = page.getByTitle("Answer all controls");
   }
 
   answerOption(label) {

--- a/frontend/e2e/pages/dashboard.page.js
+++ b/frontend/e2e/pages/dashboard.page.js
@@ -2,43 +2,64 @@ class DashboardPage {
   constructor(page) {
     this.page = page;
 
-    this.welcomeHeading = page.getByText(/welcome back/i);
-    this.newProjectButton = page.getByRole("button", { name: /new project/i });
+    // Full text interpolates the user's name ("Welcome back, {name}! Manage
+    // your AI maturity assessments") — dynamic, so this stays a substring
+    // match, not exact.
+    this.welcomeHeading = page.getByText("Welcome back");
+    this.newProjectButton = page.getByRole("button", { name: "New Project", exact: true });
 
-    this.createDialog = page.getByRole("dialog").filter({ hasText: /create new project/i });
-    this.nameInput = this.createDialog.getByPlaceholder(/enter project name/i);
-    this.descriptionInput = this.createDialog.getByPlaceholder(/describe your ai system/i);
-    this.createSubmitButton = this.createDialog.getByRole("button", { name: /create project/i });
+    // Radix wires each Dialog's <DialogTitle> to aria-labelledby, so the
+    // dialog's accessible `name` is the title text itself — no need to
+    // content-scan the whole dialog body with hasText.
+    this.createDialog = page.getByRole("dialog", { name: "Create New Project", exact: true });
+    this.nameInput = this.createDialog.getByPlaceholder("Enter project name", { exact: true });
+    this.descriptionInput = this.createDialog.getByPlaceholder("Describe your AI system", { exact: true });
+    this.createSubmitButton = page.getByRole("button", { name: "Create Project", exact: true });
 
-    this.deleteDialog = page.getByRole("dialog").filter({ hasText: /delete project/i });
-    this.deleteConfirmButton = this.deleteDialog.getByRole("button", { name: /^delete/i });
+    this.deleteDialog = page.getByRole("dialog", { name: "Delete Project", exact: true });
+    this.deleteConfirmButton = this.deleteDialog.getByRole("button", { name: "Delete", exact: true });
 
-    // Shown after clicking "Start" on a new project.
-    this.pathModal = page.getByRole("dialog").filter({ hasText: /choose your path/i });
-    this.continueAimaButton = page.getByRole("button", { name: /continue with aima/i });
+    // Shown after clicking "Start" on a new project. Unlike the dialogs above,
+    // PathSelectionModal.tsx renders its "Choose Your Path" heading as a plain
+    // <h2>, not Radix's <DialogTitle> — so this dialog has no aria-labelledby
+    // and no accessible `name` to match on. hasText is the only option here
+    // until that component is fixed to use DialogTitle.
+    this.pathModal = page.getByRole("dialog").filter({ hasText: "Choose Your Path" });
+    this.continueAimaButton = page.getByRole("button", { name: "Continue with AIMA", exact: true });
   }
 
   card(name) {
     return this.page
       .locator("div", { hasText: name })
-      .filter({ has: this.page.getByRole("button", { name: /open menu/i }) })
+      .filter({ has: this.page.getByRole("button", { name: "Open menu", exact: true }) })
       .last();
   }
 
   cardMenuButton(name) {
-    return this.card(name).getByRole("button", { name: /open menu/i });
+    return this.card(name).getByRole("button", { name: "Open menu", exact: true });
   }
 
   // The card's name/"Open menu" button and its "Start Assessment"/"Continue
   // Assessment" CTA sit under different wrapper divs, so this requires both
-  // to be present before narrowing to the innermost match.
+  // to be present before narrowing to the innermost match. The CTA is always
+  // the full "Start Assessment"/"Continue Assessment" (never a bare "Start"/
+  // "Continue" — confirmed against dashboard/page.tsx's
+  // `project.status === 'in_progress' ? 'Continue Assessment' :
+  // 'Start Assessment'`), so .or() of the two exact strings replaces what
+  // was previously one optional-suffix regex.
   cardStartButton(name) {
-    return this.page
-      .locator("div", { hasText: name })
-      .filter({ has: this.page.getByRole("button", { name: /open menu/i }) })
-      .filter({ has: this.page.getByRole("button", { name: /^(start|continue)(\s+assessment)?$/i }) })
-      .last()
-      .getByRole("button", { name: /^(start|continue)(\s+assessment)?$/i });
+    const ctaButton = (scope) =>
+      scope
+        .getByRole("button", { name: "Start Assessment", exact: true })
+        .or(scope.getByRole("button", { name: "Continue Assessment", exact: true }));
+
+    return ctaButton(
+      this.page
+        .locator("div", { hasText: name })
+        .filter({ has: this.page.getByRole("button", { name: "Open menu", exact: true }) })
+        .filter({ has: ctaButton(this.page) })
+        .last()
+    );
   }
 
   async goto() {
@@ -46,15 +67,30 @@ class DashboardPage {
     await this.welcomeHeading.waitFor();
   }
 
+  // Waits on the actual `POST /projects` response (201) rather than inferring
+  // success from the dialog closing and the name appearing somewhere on the
+  // page — the latter can't distinguish a real failure from a slow render,
+  // and can't tell two same-named cards apart. Returns the created project.
   async createProject(name, description) {
     await this.goto();
     await this.newProjectButton.click();
     await this.createDialog.waitFor();
     await this.nameInput.fill(name);
     if (description) await this.descriptionInput.fill(description);
-    await this.createSubmitButton.click();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (res) =>
+          res.request().method() === "POST" &&
+          res.url().endsWith("/projects") &&
+          res.status() === 201
+      ),
+      this.createSubmitButton.click(),
+    ]);
     await this.createDialog.waitFor({ state: "hidden" });
-    await this.page.getByText(name).first().waitFor();
+
+    const { project } = await response.json();
+    return project;
   }
 
   // Clicks a project's "Start"/"Continue" and resolves the AIMA path if a new
@@ -75,9 +111,19 @@ class DashboardPage {
 
   async deleteProjectCard(name) {
     await this.cardMenuButton(name).click();
-    await this.page.getByRole("menuitem", { name: /delete/i }).click();
+    await this.page.getByRole("menuitem", { name: "Delete", exact: true }).click();
     await this.deleteDialog.waitFor();
-    await this.deleteConfirmButton.click();
+    await this.page.getByRole("button", { name: "Delete", exact: true }).click();
+
+    await Promise.all([
+      this.page.waitForResponse(
+        (res) =>
+          res.request().method() === "DELETE" &&
+          /\/projects\/[0-9a-f-]{36}$/i.test(res.url()) &&
+          res.status() === 200
+      ),
+      this.deleteConfirmButton.click(),
+    ]);
     await this.deleteDialog.waitFor({ state: "hidden" });
   }
 

--- a/frontend/e2e/pages/dashboard.page.js
+++ b/frontend/e2e/pages/dashboard.page.js
@@ -113,7 +113,6 @@ class DashboardPage {
     await this.cardMenuButton(name).click();
     await this.page.getByRole("menuitem", { name: "Delete", exact: true }).click();
     await this.deleteDialog.waitFor();
-    await this.page.getByRole("button", { name: "Delete", exact: true }).click();
 
     await Promise.all([
       this.page.waitForResponse(

--- a/frontend/e2e/pages/fairness-api.page.js
+++ b/frontend/e2e/pages/fairness-api.page.js
@@ -1,0 +1,81 @@
+// API Automated Testing path of Bias & Fairness Testing
+// (/assess/<id>/fairness-bias/api-endpoint), backed by the same
+// ApiTestingTool component as vulnerability-assessment.page.js (mode
+// "api-testing" here vs "vulnerability" there) — same field ids, different
+// submit button label and base route.
+
+// A deliberately stereotyped "model response" (gender + occupation), used the
+// same way vulnerability-assessment.spec.js uses its canned refusal: a fixed,
+// known-content answer that httpbin.org/post echoes back verbatim, letting
+// the test assert the bias detector actually flags an obvious stereotype
+// rather than just checking that a job runs to completion.
+const STEREOTYPED_RESPONSE =
+  "As a nurse, she is naturally caring and gentle, while as an engineer, he is naturally logical and better with numbers.";
+
+class FairnessApiEndpointPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText("API Automated Fairness Testing", { exact: true }).first();
+
+    this.endpointInput = page.locator("#api-endpoint");
+    this.requestTemplateInput = page.locator("#request-template");
+    this.responseKeyInput = page.locator("#response-key-path");
+
+    this.startButton = page.getByRole("button", { name: "Start Fairness Evaluation", exact: true });
+    // ApiTestingTool.tsx's handleTestModel (the handler this mode uses) falls
+    // back to exactly this string when the caught error has no `.message` —
+    // the mode="vulnerability" page has a different fallback string, so this
+    // one doesn't need to match both.
+    this.jobStartError = page.getByText("Failed to schedule evaluation", { exact: true });
+
+    // ApiHistory.tsx renders "API Test History" for routeMode="fairness"
+    // (vs "Vulnerability Scan History" for the other mode).
+    this.historyHeading = page.getByText("API Test History", { exact: true }).first();
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias/api-endpoint`, { waitUntil: "domcontentloaded" });
+    await this.endpointInput.waitFor({ timeout: 30_000 });
+  }
+
+  async configure({
+    url = "https://httpbin.org/post",
+    requestTemplate = `{\n  "prompt": "{{prompt}}",\n  "model_response": "${STEREOTYPED_RESPONSE}"\n}`,
+    responseKey = "json.model_response",
+  } = {}) {
+    await this.endpointInput.fill(url);
+    if (requestTemplate) {
+      await this.requestTemplateInput.fill(requestTemplate);
+    }
+    await this.responseKeyInput.fill(responseKey);
+  }
+
+  async startTest() {
+    await this.startButton.isEnabled({ timeout: 15_000 });
+    await this.startButton.click();
+    await this.page.waitForURL(/\/fairness-bias\/api-endpoint\/job\/[\w-]+/i, { timeout: 30_000 });
+    const match = this.page.url().match(/\/job\/([\w-]+)/i);
+    return match ? match[1] : null;
+  }
+}
+
+class FairnessApiHistoryDetailPage {
+  constructor(page) {
+    this.page = page;
+    this.heading = page.getByText("API Report Details", { exact: true });
+    this.avgOverallScoreLabel = page.getByText("Avg Overall Score", { exact: true });
+    this.avgBiasScoreLabel = page.getByText("Avg Bias Score", { exact: true });
+  }
+
+  async goto(projectId, reportId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias/api-history/${reportId}`, { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  valueAfter(labelLocator) {
+    return labelLocator.locator("xpath=following-sibling::div").first();
+  }
+}
+
+module.exports = { FairnessApiEndpointPage, FairnessApiHistoryDetailPage, STEREOTYPED_RESPONSE };

--- a/frontend/e2e/pages/fairness-dataset.page.js
+++ b/frontend/e2e/pages/fairness-dataset.page.js
@@ -1,0 +1,85 @@
+// Dataset Testing path of Bias & Fairness Testing
+// (/assess/<id>/fairness-bias/dataset-testing -> .../report).
+//
+// A CSV engineered for a clear, unambiguous disparity: every "Male" row is
+// "approved", every "Female" row is "denied" (10 rows, 5/5 split) — headers
+// "gender" and "loan_approved" both hit the backend's SENSITIVE_KEYWORDS /
+// TARGET_COLUMN_KEYWORDS lists (datasetFairness.ts), and "approved"/"denied"
+// are recognized POSITIVE_KEYWORDS/NEGATIVE_KEYWORDS. This should force a
+// 100% vs 0% selection rate (disparity 1.0, "fail" verdict) — good for
+// asserting the detector actually catches an obvious case, not just that a
+// report renders. The free-text "notes" column carries a mild occupational
+// stereotype so toxicity/relevancy/faithfulness aren't "insufficient_data".
+const BIASED_CSV = [
+  "gender,age,income,notes,loan_approved",
+  'Male,35,72000,"He is a strong candidate for a senior engineering role.",approved',
+  'Male,42,68000,"He has excellent leadership and analytical skills.",approved',
+  'Male,29,61000,"He is naturally good with technical problem solving.",approved',
+  'Male,50,75000,"He shows strong financial discipline.",approved',
+  'Male,33,80000,"He is a reliable and steady earner.",approved',
+  'Female,31,70000,"She is naturally more suited to a caring, supportive role.",denied',
+  'Female,45,65000,"She may struggle with the technical demands of the job.",denied',
+  'Female,28,60000,"She seems less focused on career advancement.",denied',
+  'Female,38,72000,"She is likely to prioritize family over work.",denied',
+  'Female,52,77000,"She is not seen as assertive enough for this role.",denied',
+].join("\n");
+
+class FairnessDatasetPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText("Dataset Testing & Evaluation", { exact: true });
+    this.fileInput = page.locator("#csv-upload");
+    this.evaluateButton = page.getByRole("button", { name: "Run Fairness Evaluation", exact: true });
+    this.previewHeading = page.getByText("Dataset Snapshot", { exact: true });
+
+    // NOTE: the old /report history/i regex never actually matched anything
+    // — ReportHistory.tsx's real heading is "Recent Evaluations", not
+    // "Report History" (confirmed against source; nothing on this page
+    // renders that phrase). Fixed here, though this locator turned out to be
+    // unused in the current specs (only fairness-manual.page.js's
+    // historyHeading — a different instance for a different heading that
+    // really does say "Manual Test History" — is actually asserted on).
+    this.historyHeading = page.getByText("Recent Evaluations", { exact: true }).first();
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias/dataset-testing`, { waitUntil: "domcontentloaded" });
+    await this.fileInput.waitFor({ state: "attached", timeout: 30_000 });
+  }
+
+  async uploadBiasedCsv(fileName = "loan-approvals.csv") {
+    await this.fileInput.setInputFiles({
+      name: fileName,
+      mimeType: "text/csv",
+      buffer: Buffer.from(BIASED_CSV, "utf-8"),
+    });
+    await this.previewHeading.waitFor({ timeout: 15_000 });
+  }
+
+  async evaluate() {
+    await this.evaluateButton.isEnabled({ timeout: 15_000 });
+    await this.evaluateButton.click();
+    await this.page.waitForURL(/\/fairness-bias\/dataset-testing\/report/i, { timeout: 30_000 });
+  }
+}
+
+class FairnessDatasetReportPage {
+  constructor(page) {
+    this.page = page;
+    this.heading = page.getByText("Fairness & Bias Evaluation Summary", { exact: true });
+    this.verdictLabel = page.getByText("Overall verdict", { exact: true }).locator("xpath=following-sibling::p").first();
+    // "{N} groups analyzed" — N is dynamic, so this stays a substring match.
+    this.sensitiveColumnsCount = page.getByText("groups analyzed");
+    // Real copy (report/page.tsx) is "No sensitive columns detected or
+    // insufficient data to compute disparities." — kept as a substring match
+    // since it's part of a longer sentence, just without the regex wrapper.
+    this.noSensitiveColumnsMessage = page.getByText("No sensitive columns detected");
+  }
+
+  async waitFor() {
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+}
+
+module.exports = { FairnessDatasetPage, FairnessDatasetReportPage, BIASED_CSV };

--- a/frontend/e2e/pages/fairness-manual.page.js
+++ b/frontend/e2e/pages/fairness-manual.page.js
@@ -1,0 +1,149 @@
+// Manual Prompt Testing path of Bias & Fairness Testing
+// (/assess/<id>/fairness-bias -> job/<jobId> -> report?jobId=<jobId>), plus
+// the separate Manual Test History list/detail views
+// (/assess/<id>/fairness-bias/manual-history[/<id>]).
+//
+// Two different "report" views exist for the same underlying manual-prompt
+// job, and they are NOT equivalent:
+//   - FairnessManualReportPage (/fairness-bias/report?jobId=X) is reached by
+//     the natural job-completion auto-redirect. It calls
+//     GET /fairness/evaluations/:projectId (ALL evaluations ever recorded for
+//     the project, not scoped to jobId at all — the jobId query param is
+//     parsed by nothing in the component) and keys them by
+//     `${category}:${questionText}` into a Map built by iterating the
+//     newest-first array with .set() — so if the same question was ever
+//     answered in an earlier job too, the OLDEST evaluation for that
+//     category+question wins, not the newest.
+//   - FairnessManualHistoryDetailPage (/fairness-bias/manual-history/<id>) is
+//     reached via the "Manual Test History" table and calls
+//     GET /fairness/manual-reports/detail/:reportId — scoped to exactly one
+//     report row, always correct for that run.
+class FairnessManualPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText("Manual Prompt Testing", { exact: true }).first();
+    this.responseTextarea = page.locator("#responseTextarea");
+    this.nextButton = page.getByRole("button", { name: "Next", exact: true });
+    this.previousButton = page.getByRole("button", { name: "Previous", exact: true });
+    this.evaluateButton = page.getByRole("button", { name: "Evaluate Assessment", exact: true });
+    this.currentQuestionText = page.locator(".card-google-blue h2");
+    // "Question {ordinal} of {total}" is genuinely dynamic — can't drop the regex.
+    this.questionOrdinal = page.getByText(/^Question \d+ of \d+$/);
+
+    this.historyHeading = page.getByText("Manual Test History", { exact: true });
+    this.historyRows = page.locator("table tbody tr");
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias`, { waitUntil: "domcontentloaded" });
+    await this.responseTextarea.waitFor({ timeout: 30_000 });
+  }
+
+  async answerCurrentQuestion(text) {
+    await this.responseTextarea.fill(text);
+  }
+
+  // Submits whatever has been answered so far and returns the jobId parsed
+  // from the resulting URL (job ids look like
+  // "fairness-prompts-1784018220389-jv4yp0x", not a UUID).
+  async submit() {
+    await this.evaluateButton.click();
+    await this.page.waitForURL(/\/fairness-bias\/job\/[\w-]+/i, { timeout: 30_000 });
+    const match = this.page.url().match(/\/job\/([\w-]+)/i);
+    return match ? match[1] : null;
+  }
+}
+
+// Shared job-status page shape for both the manual-prompt and API-automated
+// paths (identical component structure, different base route). `basePath`
+// e.g. `/assess/<id>/fairness-bias` (manual) or
+// `/assess/<id>/fairness-bias/api-endpoint` (API).
+class FairnessJobPage {
+  constructor(page, basePath) {
+    this.page = page;
+    this.basePath = basePath;
+    this.jobIdLabel = page.getByText("Job ID", { exact: true });
+    this.statusBadge = page.locator("span.rounded-full.text-xs.font-semibold").first();
+    this.viewReportButton = page.getByRole("button", { name: "View report", exact: true });
+  }
+
+  async waitForTerminalStatus(timeoutMs = 6 * 60 * 1000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const text = (await this.statusBadge.textContent().catch(() => null))?.trim().toLowerCase();
+      if (text && ["completed", "success", "partial_success", "failed"].includes(text)) {
+        return text;
+      }
+      await this.page.waitForTimeout(4000);
+    }
+    throw new Error(`Job did not reach a terminal status within ${timeoutMs}ms`);
+  }
+
+  // BUG (confirmed live 2x, 2026-07-21/22): the manual-prompt job page's
+  // "Auto redirect when completed" effect
+  // (fairness-bias/job/[jobId]/page.tsx:91-100) lists its own
+  // `redirectScheduled` flag in the useEffect dependency array and returns a
+  // `clearTimeout` cleanup. Calling `setRedirectScheduled(true)` inside the
+  // effect makes React re-run that same effect (since redirectScheduled is a
+  // dependency) — cleanup fires FIRST and clears the just-scheduled 2000ms
+  // timeout before it can ever elapse. The redirect never fires, full stop
+  // (verified idle on the job page for 85+ seconds past terminal status,
+  // twice). Does NOT affect the API-automated-testing job page, which has an
+  // equivalent effect but no cleanup function to cancel its async redirect.
+  // Work around it here the way a real stuck user would: click "View report"
+  // manually (that path is NOT broken).
+  async clickViewReportManually(timeoutMs = 15_000) {
+    await this.viewReportButton.isEnabled({ timeout: timeoutMs });
+    await this.viewReportButton.click();
+  }
+}
+
+class FairnessManualReportPage {
+  constructor(page) {
+    this.page = page;
+    this.heading = page.getByText("Fairness & Bias Report", { exact: true });
+    this.avgScore = page.getByText("Avg Score", { exact: true }).locator("xpath=following-sibling::div").first();
+  }
+
+  async goto(projectId, jobId) {
+    const url = jobId
+      ? `/assess/${projectId}/fairness-bias/report?jobId=${jobId}`
+      : `/assess/${projectId}/fairness-bias/report`;
+    await this.page.goto(url, { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  // This spec only ever answers a single question per run (deliberately
+  // reused across runs to probe the staleness bug — see the class-level
+  // comment), so there is always at most one "Your Response" block on the
+  // page: simpler and more robust than trying to scope by prompt text.
+  async firstResponseText() {
+    const block = this.page.getByText("Your Response", { exact: true }).first().locator("xpath=following-sibling::div").first();
+    return (await block.textContent())?.trim();
+  }
+}
+
+class FairnessManualHistoryDetailPage {
+  constructor(page) {
+    this.page = page;
+    this.heading = page.getByText("Manual Prompt Report Details", { exact: true });
+  }
+
+  async goto(projectId, reportId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias/manual-history/${reportId}`, { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  async firstResponseText() {
+    const block = this.page.getByText("Your Response", { exact: true }).first().locator("xpath=following-sibling::div").first();
+    return (await block.textContent())?.trim();
+  }
+}
+
+module.exports = {
+  FairnessManualPage,
+  FairnessJobPage,
+  FairnessManualReportPage,
+  FairnessManualHistoryDetailPage,
+};

--- a/frontend/e2e/pages/fairness-options.page.js
+++ b/frontend/e2e/pages/fairness-options.page.js
@@ -1,0 +1,28 @@
+// The "Bias & Fairness Testing" hub (/assess/<id>/fairness-bias/options).
+// Wizard-gated premium route (see WizardGateProvider's isPremiumRoute set in
+// layout.tsx, alongside CRC / vulnerability-assessment / inventory /
+// premium-domains) — complete the AI System Profile wizard first.
+
+class FairnessOptionsPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText("Bias & Fairness Testing Options", { exact: true });
+    this.manualCard = page.getByRole("heading", { name: "Manual Prompt Testing", exact: true });
+    this.apiCard = page.getByRole("heading", { name: "API Automated Testing", exact: true });
+    this.datasetCard = page.getByRole("heading", { name: "Dataset Testing", exact: true });
+    this.continueButton = page.getByRole("button", { name: "Continue", exact: true });
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/fairness-bias/options`, { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  async selectAndContinue(cardLocator) {
+    await cardLocator.click();
+    await this.continueButton.click();
+  }
+}
+
+module.exports = { FairnessOptionsPage };

--- a/frontend/e2e/pages/forgot-password.page.js
+++ b/frontend/e2e/pages/forgot-password.page.js
@@ -1,0 +1,22 @@
+class ForgotPasswordPage {
+  constructor(page) {
+    this.page = page;
+
+    this.emailInput = page.locator("#email");
+    this.sendButton = page.getByRole("button", { name: /send reset link/i });
+    this.checkInboxHeading = page.getByText(/check your inbox/i);
+    this.tryDifferentEmailButton = page.getByRole("button", { name: /try a different email/i });
+  }
+
+  async goto() {
+    await this.page.goto("/auth/forgot-password", { waitUntil: "domcontentloaded" });
+    await this.emailInput.waitFor();
+  }
+
+  async submit(email) {
+    await this.emailInput.fill(email);
+    await this.sendButton.click();
+  }
+}
+
+module.exports = { ForgotPasswordPage };

--- a/frontend/e2e/pages/forgot-password.page.js
+++ b/frontend/e2e/pages/forgot-password.page.js
@@ -3,9 +3,9 @@ class ForgotPasswordPage {
     this.page = page;
 
     this.emailInput = page.locator("#email");
-    this.sendButton = page.getByRole("button", { name: /send reset link/i });
-    this.checkInboxHeading = page.getByText(/check your inbox/i);
-    this.tryDifferentEmailButton = page.getByRole("button", { name: /try a different email/i });
+    this.sendButton = page.getByRole("button", { name: "Send reset link", exact: true });
+    this.checkInboxHeading = page.getByText("Check your inbox", { exact: true });
+    this.tryDifferentEmailButton = page.getByRole("button", { name: "Try a different email", exact: true });
   }
 
   async goto() {

--- a/frontend/e2e/pages/inventory.page.js
+++ b/frontend/e2e/pages/inventory.page.js
@@ -24,14 +24,11 @@ class InventoryPage {
 
   async goto(projectId) {
     await this.page.goto(`/assess/${projectId}/inventory`, { waitUntil: "domcontentloaded" });
-    await Promise.race([
-      this.addComponentButton.waitFor({ timeout: 30_000 }).catch(() => {}),
-      this.emptyState.waitFor({ timeout: 30_000 }).catch(() => {}),
-    ]);
+    await this.addComponentButton.or(this.emptyState).waitFor({ timeout: 30_000 });
   }
 
   row(componentName) {
-    return this.page.getByRole("row", { name: new RegExp(componentName, "i") });
+    return this.page.getByRole("row", { name: componentName });
   }
 
   // Icon-only ghost buttons (IconEdit/IconTrash from @tabler/icons-react)

--- a/frontend/e2e/pages/inventory.page.js
+++ b/frontend/e2e/pages/inventory.page.js
@@ -1,0 +1,75 @@
+class InventoryPage {
+  constructor(page) {
+    this.page = page;
+
+    this.addComponentButton = page.getByRole("button", { name: /add (component|your first component)/i });
+    this.emptyState = page.getByText(/component inventory is empty/i);
+
+    this.formDialog = page.getByRole("dialog").filter({ hasText: /add new ai component|edit ai component/i });
+    this.roleInput = this.formDialog.getByPlaceholder(/explain exactly what this component does/i);
+    this.noDataProcessingButton = this.formDialog.getByRole("button", { name: /set to 'no data processing'/i });
+    this.createButton = this.formDialog.getByRole("button", { name: /create component|save changes/i });
+
+    this.savedToast = page.getByText(/component (added to inventory|updated successfully)/i);
+
+    // The detail Sheet and the Delete-confirm Dialog are both Radix
+    // Dialog.Content under the hood (role="dialog"); only one is open at a
+    // time (openAddForm/openEditForm force the detail Sheet closed while the
+    // form Dialog is open), so a plain role query is unambiguous per step.
+    this.detailPanel = page.getByRole("dialog");
+    this.deleteDialog = page.getByRole("dialog").filter({ hasText: /remove ai component/i });
+    this.deleteConfirmButton = this.deleteDialog.getByRole("button", { name: /^delete component$/i });
+    this.deletedToast = page.getByText(/component removed/i);
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/inventory`, { waitUntil: "domcontentloaded" });
+    await Promise.race([
+      this.addComponentButton.waitFor({ timeout: 30_000 }).catch(() => {}),
+      this.emptyState.waitFor({ timeout: 30_000 }).catch(() => {}),
+    ]);
+  }
+
+  row(componentName) {
+    return this.page.getByRole("row", { name: new RegExp(componentName, "i") });
+  }
+
+  // Icon-only ghost buttons (IconEdit/IconTrash from @tabler/icons-react)
+  // with no accessible name — tabler-icons-react stamps a stable
+  // `tabler-icon-<name>` class on every icon's <svg>, so that's the only
+  // reliable hook.
+  deleteTriggerButton() {
+    return this.detailPanel.locator("button:has(svg.tabler-icon-trash)");
+  }
+
+  // openAddForm() (frontend/src/app/assess/[projectId]/inventory/page.tsx)
+  // pre-fills Type=Closed Foundation Model, Provider=OpenAI, Name from the
+  // vendor catalog's first OpenAI model, and Status=Active — so the only
+  // required fields actually missing are Role in AI System (free text) and
+  // Data Categories (the "No Data Processing" shortcut satisfies it in one
+  // click without opening the vendor-risk-assessment flow a real category
+  // would trigger).
+  async addDefaultComponent(role) {
+    await this.addComponentButton.click();
+    await this.formDialog.waitFor();
+    await this.roleInput.fill(role);
+    await this.noDataProcessingButton.click();
+    await this.createButton.click();
+    await this.formDialog.waitFor({ state: "hidden" });
+  }
+
+  async openDetail(componentName) {
+    await this.row(componentName).click();
+    await this.detailPanel.waitFor();
+  }
+
+  async deleteComponent(componentName) {
+    await this.openDetail(componentName);
+    await this.deleteTriggerButton().click();
+    await this.deleteDialog.waitFor();
+    await this.deleteConfirmButton.click();
+    await this.deleteDialog.waitFor({ state: "hidden" });
+  }
+}
+
+module.exports = { InventoryPage };

--- a/frontend/e2e/pages/inventory.page.js
+++ b/frontend/e2e/pages/inventory.page.js
@@ -2,11 +2,11 @@ class InventoryPage {
   constructor(page) {
     this.page = page;
 
-    // Two mutually-exclusive fixed button labels depending on whether the
-    // inventory already has components.
-    this.addComponentButton = page
-      .getByRole("button", { name: "Add Component", exact: true })
-      .or(page.getByRole("button", { name: "Add Your First Component", exact: true }));
+    // The header "Add Component" button is always rendered, empty inventory
+    // or not — the empty-state's "Add Your First Component" button is an
+    // additional CTA shown alongside it, not a replacement for it, so match
+    // on the header button alone rather than a non-exclusive .or().
+    this.addComponentButton = page.getByRole("button", { name: "Add Component", exact: true });
     // Full copy is "Your component inventory is empty. Start by adding your
     // first AI system component." — substring match, not exact.
     this.emptyState = page.getByText("component inventory is empty");
@@ -19,7 +19,13 @@ class InventoryPage {
       .getByRole("dialog", { name: "Add New AI Component", exact: true })
       .or(page.getByRole("dialog", { name: "Edit AI Component", exact: true }));
     this.roleInput = this.formDialog.getByPlaceholder("Explain exactly what this component does");
-    this.noDataProcessingButton = this.formDialog.getByRole("button", { name: "Set to 'No Data Processing'", exact: true });
+    // Not getByRole: the button is nested inside the <label> for "Data
+    // Categories Sent/Processed *" (inventory/page.tsx), so browsers compute
+    // its accessible name from that wrapping label's text, not its own —
+    // getByRole("button", {name: "Set to 'No Data Processing'"}) never
+    // matches. Matching on its visible text sidesteps the broken a11y name
+    // without depending on it being fixed.
+    this.noDataProcessingButton = this.formDialog.getByText("Set to 'No Data Processing'", { exact: true });
     // formMode === "add" ? "Create Component" : "Save Changes" — two
     // mutually-exclusive fixed strings.
     this.createButton = this.formDialog

--- a/frontend/e2e/pages/inventory.page.js
+++ b/frontend/e2e/pages/inventory.page.js
@@ -2,24 +2,43 @@ class InventoryPage {
   constructor(page) {
     this.page = page;
 
-    this.addComponentButton = page.getByRole("button", { name: /add (component|your first component)/i });
-    this.emptyState = page.getByText(/component inventory is empty/i);
+    // Two mutually-exclusive fixed button labels depending on whether the
+    // inventory already has components.
+    this.addComponentButton = page
+      .getByRole("button", { name: "Add Component", exact: true })
+      .or(page.getByRole("button", { name: "Add Your First Component", exact: true }));
+    // Full copy is "Your component inventory is empty. Start by adding your
+    // first AI system component." — substring match, not exact.
+    this.emptyState = page.getByText("component inventory is empty");
 
-    this.formDialog = page.getByRole("dialog").filter({ hasText: /add new ai component|edit ai component/i });
-    this.roleInput = this.formDialog.getByPlaceholder(/explain exactly what this component does/i);
-    this.noDataProcessingButton = this.formDialog.getByRole("button", { name: /set to 'no data processing'/i });
-    this.createButton = this.formDialog.getByRole("button", { name: /create component|save changes/i });
+    // Radix wires <DialogTitle> to aria-labelledby, so both dialogs' actual
+    // titles ("Add New AI Component" / "Edit AI Component" / "Remove AI
+    // Component") are their accessible `name` — match on that instead of
+    // scanning the whole dialog body with hasText.
+    this.formDialog = page
+      .getByRole("dialog", { name: "Add New AI Component", exact: true })
+      .or(page.getByRole("dialog", { name: "Edit AI Component", exact: true }));
+    this.roleInput = this.formDialog.getByPlaceholder("Explain exactly what this component does");
+    this.noDataProcessingButton = this.formDialog.getByRole("button", { name: "Set to 'No Data Processing'", exact: true });
+    // formMode === "add" ? "Create Component" : "Save Changes" — two
+    // mutually-exclusive fixed strings.
+    this.createButton = this.formDialog
+      .getByRole("button", { name: "Create Component", exact: true })
+      .or(this.formDialog.getByRole("button", { name: "Save Changes", exact: true }));
 
-    this.savedToast = page.getByText(/component (added to inventory|updated successfully)/i);
+    // Two mutually-exclusive fixed toast messages.
+    this.savedToast = page
+      .getByText("Component added to inventory", { exact: true })
+      .or(page.getByText("Component updated successfully", { exact: true }));
 
     // The detail Sheet and the Delete-confirm Dialog are both Radix
     // Dialog.Content under the hood (role="dialog"); only one is open at a
     // time (openAddForm/openEditForm force the detail Sheet closed while the
     // form Dialog is open), so a plain role query is unambiguous per step.
     this.detailPanel = page.getByRole("dialog");
-    this.deleteDialog = page.getByRole("dialog").filter({ hasText: /remove ai component/i });
-    this.deleteConfirmButton = this.deleteDialog.getByRole("button", { name: /^delete component$/i });
-    this.deletedToast = page.getByText(/component removed/i);
+    this.deleteDialog = page.getByRole("dialog", { name: "Remove AI Component", exact: true });
+    this.deleteConfirmButton = this.deleteDialog.getByRole("button", { name: "Delete Component", exact: true });
+    this.deletedToast = page.getByText("Component removed from inventory", { exact: true });
   }
 
   async goto(projectId) {
@@ -27,6 +46,11 @@ class InventoryPage {
     await this.addComponentButton.or(this.emptyState).waitFor({ timeout: 30_000 });
   }
 
+  // `componentName` is caller-supplied dynamic data, not UI copy —
+  // Playwright's role `name` matching is already a case-insensitive
+  // substring match on a plain string, so wrapping it in a RegExp added
+  // nothing except a latent bug: unescaped regex metacharacters in a real
+  // component name (e.g. a "." or "+") would be interpreted as regex syntax.
   row(componentName) {
     return this.page.getByRole("row", { name: componentName });
   }
@@ -46,13 +70,26 @@ class InventoryPage {
   // Data Categories (the "No Data Processing" shortcut satisfies it in one
   // click without opening the vendor-risk-assessment flow a real category
   // would trigger).
+  // Waits on the actual `POST /inventory/:projectId` response (201) rather
+  // than just the dialog closing.
   async addDefaultComponent(role) {
     await this.addComponentButton.click();
     await this.formDialog.waitFor();
     await this.roleInput.fill(role);
     await this.noDataProcessingButton.click();
-    await this.createButton.click();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (res) =>
+          res.request().method() === "POST" &&
+          /\/inventory\/[0-9a-f-]{36}$/i.test(res.url()) &&
+          res.status() === 201
+      ),
+      this.createButton.click(),
+    ]);
     await this.formDialog.waitFor({ state: "hidden" });
+
+    return response.json();
   }
 
   async openDetail(componentName) {
@@ -60,11 +97,22 @@ class InventoryPage {
     await this.detailPanel.waitFor();
   }
 
+  // Waits on the actual `DELETE /inventory/:projectId/:id` response (200)
+  // rather than just the dialog closing.
   async deleteComponent(componentName) {
     await this.openDetail(componentName);
     await this.deleteTriggerButton().click();
     await this.deleteDialog.waitFor();
-    await this.deleteConfirmButton.click();
+
+    await Promise.all([
+      this.page.waitForResponse(
+        (res) =>
+          res.request().method() === "DELETE" &&
+          /\/inventory\/[0-9a-f-]{36}\/[0-9a-f-]{36}$/i.test(res.url()) &&
+          res.status() === 200
+      ),
+      this.deleteConfirmButton.click(),
+    ]);
     await this.deleteDialog.waitFor({ state: "hidden" });
   }
 }

--- a/frontend/e2e/pages/invite.page.js
+++ b/frontend/e2e/pages/invite.page.js
@@ -1,0 +1,22 @@
+class InvitePage {
+  constructor(page) {
+    this.page = page;
+
+    this.invalidHeading = page.getByText(/invalid invitation/i);
+    this.projectInvitationHeading = page.getByText(/project invitation/i);
+    this.acceptButton = page.getByRole("button", { name: /^accept invitation$/i });
+    this.declineButton = page.getByRole("button", { name: /^decline invitation$/i });
+    this.signInAndAcceptButton = page.getByRole("button", { name: /sign in & accept/i });
+    this.createAccountButton = page.getByRole("button", { name: /create account & accept/i });
+  }
+
+  // token=null exercises the "No invitation token provided" path;
+  // a bogus/expired token exercises the "Invalid or expired invitation
+  // token" path (both render the same invalidHeading card).
+  async goto(token) {
+    const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+    await this.page.goto(`/invite/accept${qs}`, { waitUntil: "domcontentloaded" });
+  }
+}
+
+module.exports = { InvitePage };

--- a/frontend/e2e/pages/invite.page.js
+++ b/frontend/e2e/pages/invite.page.js
@@ -2,12 +2,12 @@ class InvitePage {
   constructor(page) {
     this.page = page;
 
-    this.invalidHeading = page.getByText(/invalid invitation/i);
-    this.projectInvitationHeading = page.getByText(/project invitation/i);
-    this.acceptButton = page.getByRole("button", { name: /^accept invitation$/i });
-    this.declineButton = page.getByRole("button", { name: /^decline invitation$/i });
-    this.signInAndAcceptButton = page.getByRole("button", { name: /sign in & accept/i });
-    this.createAccountButton = page.getByRole("button", { name: /create account & accept/i });
+    this.invalidHeading = page.getByText("Invalid Invitation", { exact: true });
+    this.projectInvitationHeading = page.getByText("Project Invitation", { exact: true });
+    this.acceptButton = page.getByRole("button", { name: "Accept Invitation", exact: true });
+    this.declineButton = page.getByRole("button", { name: "Decline Invitation", exact: true });
+    this.signInAndAcceptButton = page.getByRole("button", { name: "Sign In & Accept", exact: true });
+    this.createAccountButton = page.getByRole("button", { name: "Create Account & Accept", exact: true });
   }
 
   // token=null exercises the "No invitation token provided" path;

--- a/frontend/e2e/pages/manage-subscription.page.js
+++ b/frontend/e2e/pages/manage-subscription.page.js
@@ -7,8 +7,12 @@ class ManageSubscriptionPage {
   constructor(page) {
     this.page = page;
 
-    this.heading = page.getByRole("heading", { name: /manage your subscription|subscription/i }).first();
-    this.faqHeading = page.getByText(/frequently asked questions/i);
+    // The real <h1> is "Subscription & Billing" — the old locator's
+    // "Manage Your Subscription" alternative never matched anything; it only
+    // worked at all because of the second, much broader "subscription"
+    // fallback (which happens to be a substring of the real heading).
+    this.heading = page.getByRole("heading", { name: "Subscription & Billing", exact: true }).first();
+    this.faqHeading = page.getByText("Frequently Asked Questions", { exact: true });
   }
 
   async goto() {

--- a/frontend/e2e/pages/manage-subscription.page.js
+++ b/frontend/e2e/pages/manage-subscription.page.js
@@ -1,0 +1,20 @@
+// Read-only coverage only, intentionally. Every action on this page (Upgrade
+// to BLOOM/BLOOM PLUS, Cancel Subscription) redirects to real Stripe billing
+// against whatever plan the shared test account currently holds — none of
+// that is safe to automate against a real account, so this page object never
+// clicks a billing action, only asserts the page renders.
+class ManageSubscriptionPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByRole("heading", { name: /manage your subscription|subscription/i }).first();
+    this.faqHeading = page.getByText(/frequently asked questions/i);
+  }
+
+  async goto() {
+    await this.page.goto("/manage-subscription", { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+}
+
+module.exports = { ManageSubscriptionPage };

--- a/frontend/e2e/pages/premium-features.page.js
+++ b/frontend/e2e/pages/premium-features.page.js
@@ -7,23 +7,28 @@ class PremiumFeaturesPage {
     // Three possible states: the feature hub (profile configured), the
     // onboarding gate (fresh premium project), or the upgrade gate (not
     // premium). Either of the first two proves the account is premium.
-    this.hubHeading = page.getByText(/take your ai governance to the next level/i);
+    this.hubHeading = page.getByText("Take your AI governance to the next level", { exact: true });
     this.onboardingHeading = page
-      .getByText(/personalize your compliance experience/i)
-      .or(page.getByText(/premium onboarding flow/i))
+      .getByText("Personalize Your Compliance Experience", { exact: true })
+      .or(page.getByText("Premium Onboarding Flow", { exact: true }))
       .first();
-    this.upgradeGate = page.getByRole("button", { name: /upgrade to premium/i });
+    this.upgradeGate = page.getByRole("button", { name: "Upgrade to Premium", exact: true });
 
-    this.vulnerabilityCard = page.getByText(/AI Vulnerability Assessment/i).first();
-    this.biasCard = page.getByText(/Automated Bias & Fairness Testing/i).first();
-    this.crcCard = page.getByText(/Compliance Readiness Controls/i).first();
-    this.premiumDomains = page.getByText(/Premium Domains Assessment/i);
+    this.vulnerabilityCard = page.getByText("AI Vulnerability Assessment", { exact: true }).first();
+    this.biasCard = page.getByText("Automated Bias & Fairness Testing", { exact: true }).first();
+    // Full card title is "Compliance Readiness Controls (CRC)" — the old
+    // regex only ever matched as a prefix of that; kept as an explicit
+    // substring match (not exact) rather than typing out the "(CRC)" suffix.
+    this.crcCard = page.getByText("Compliance Readiness Controls");
+    this.premiumDomains = page.getByText("Premium Domains Assessment", { exact: true });
 
     // Left assess sidebar — present for a premium account, absent/locked
-    // otherwise.
-    this.sidebarVulnerability = page.getByText(/AI Vulnerability Assessment/i).first();
+    // otherwise. Sidebar labels are shorter than the feature-hub card
+    // titles above ("AI Vulnerability Assessment" / "Bias & Fairness
+    // Testing", not "Automated Bias & Fairness Testing").
+    this.sidebarVulnerability = page.getByText("AI Vulnerability Assessment", { exact: true }).first();
     this.sidebarCrc = page.getByText("CRC", { exact: true }).first();
-    this.sidebarBias = page.getByText(/Bias & Fairness Testing/i).first();
+    this.sidebarBias = page.getByText("Bias & Fairness Testing", { exact: true }).first();
 
     this.wizard = new WizardPage(page);
   }

--- a/frontend/e2e/pages/premium-features.page.js
+++ b/frontend/e2e/pages/premium-features.page.js
@@ -47,15 +47,16 @@ class PremiumFeaturesPage {
 
   // Completes (and applies) the AI System Profile wizard that gates CRC /
   // premium features for a fresh premium project. Returns true if it ran the
-  // wizard, false if it was already applied.
-  async completeSystemProfileWizard(projectId) {
+  // wizard, false if it was already applied. See WizardPage.complete() re:
+  // systemName — it becomes the project's new display name.
+  async completeSystemProfileWizard(projectId, systemName) {
     await this.goto(projectId);
     await Promise.race([
       this.wizard.configureButton.waitFor({ timeout: 30_000 }).catch(() => {}),
       this.hubHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
     ]);
     if (!(await this.wizard.configureButton.isVisible().catch(() => false))) return false; // already applied
-    await this.wizard.complete();
+    await this.wizard.complete(systemName);
     return true;
   }
 }

--- a/frontend/e2e/pages/project-settings.page.js
+++ b/frontend/e2e/pages/project-settings.page.js
@@ -1,0 +1,28 @@
+class ProjectSettingsPage {
+  constructor(page) {
+    this.page = page;
+
+    this.nameInput = page.locator("#project-name");
+    this.descriptionInput = page.locator("#project-description");
+    this.updateButton = page.getByRole("button", { name: /update project/i });
+    this.savedToast = page.getByText(/project updated successfully/i);
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/settings`, { waitUntil: "domcontentloaded" });
+    await this.nameInput.waitFor({ timeout: 30_000 });
+  }
+
+  async updateDetails({ name, description }) {
+    if (name !== undefined) {
+      await this.nameInput.fill(name);
+    }
+    if (description !== undefined) {
+      await this.descriptionInput.fill(description);
+    }
+    await this.updateButton.click();
+    await this.savedToast.waitFor({ timeout: 15_000 });
+  }
+}
+
+module.exports = { ProjectSettingsPage };

--- a/frontend/e2e/pages/project-settings.page.js
+++ b/frontend/e2e/pages/project-settings.page.js
@@ -4,8 +4,8 @@ class ProjectSettingsPage {
 
     this.nameInput = page.locator("#project-name");
     this.descriptionInput = page.locator("#project-description");
-    this.updateButton = page.getByRole("button", { name: /update project/i });
-    this.savedToast = page.getByText(/project updated successfully/i);
+    this.updateButton = page.getByRole("button", { name: "Update Project", exact: true });
+    this.savedToast = page.getByText("Project updated successfully", { exact: true });
   }
 
   async goto(projectId) {

--- a/frontend/e2e/pages/report.page.js
+++ b/frontend/e2e/pages/report.page.js
@@ -2,26 +2,30 @@ class ReportPage {
   constructor(page) {
     this.page = page;
 
-    this.overallScoreLabel = page.getByText(/overall score/i);
-    // The big "X.XX" figure — renders before the domain breakdown in DOM
-    // order, so .first() reliably targets it over a per-domain score.
+    this.overallScoreLabel = page.getByText("Overall Score", { exact: true });
+    // The big "X.XX" figure is genuinely dynamic (a live computed score), so
+    // this is one of the few locators here that has to stay a regex.
+    // Renders before the domain breakdown in DOM order, so .first() reliably
+    // targets it over a per-domain score.
     this.overallScoreValue = page.getByText(/^\d\.\d{2}$/).first();
-    this.questionsEvaluated = page.getByText(/questions evaluated/i);
+    this.questionsEvaluated = page.getByText("Questions Evaluated", { exact: true });
     this.questionsEvaluatedValue = page
-      .locator("div", { hasText: /questions evaluated/i })
+      .locator("div", { hasText: "Questions Evaluated" })
       .last()
-      .getByText(/^\d+$/);
-    this.domainBreakdown = page.getByText(/domain maturity breakdown/i);
-    // Premium projects also render their premium domain(s); on this
-    // deployment it's named "Test Premium Control Family …".
-    this.premiumDomainRow = page.getByText(/premium control family/i).first();
+      .getByText(/^\d+$/); // dynamic count, unavoidably a regex
+    this.domainBreakdown = page.getByText("Domain Maturity Breakdown", { exact: true });
+    // Premium projects also render their premium domain(s) — the domain's
+    // name itself is backend/dataset-driven, not fixed UI copy (on this
+    // deployment it happens to be "Test Premium Control Family …"), so this
+    // stays a substring match rather than an exact one.
+    this.premiumDomainRow = page.getByText("Premium Control Family").first();
 
-    // Disabled and reads "Preparing insights..." until the AI-insights job
-    // finishes; only then does it enable and read "Download Report".
-    this.downloadButton = page.getByRole("button", { name: /download report/i });
-    this.preparingInsights = page.getByText(/preparing insights/i);
+    // Toggles between "Generating..." / "Preparing insights..." (disabled,
+    // while the AI-insights job runs) / "Download Report" (idle, enabled).
+    this.downloadButton = page.getByRole("button", { name: "Download Report", exact: true });
+    this.preparingInsights = page.getByText("Preparing insights...", { exact: true });
 
-    this.backToAssessmentButton = page.getByRole("button", { name: /back to assessment/i }).first();
+    this.backToAssessmentButton = page.getByRole("button", { name: "Back to Assessment", exact: true }).first();
   }
 
   async download() {

--- a/frontend/e2e/pages/reset-password.page.js
+++ b/frontend/e2e/pages/reset-password.page.js
@@ -1,0 +1,32 @@
+class ResetPasswordPage {
+  constructor(page) {
+    this.page = page;
+
+    this.invalidLinkHeading = page.getByText(/invalid reset link/i);
+    this.passwordInput = page.locator("#password");
+    this.confirmPasswordInput = page.locator("#confirmPassword");
+    this.submitButton = page.getByRole("button", { name: /^reset password$/i });
+    this.successHeading = page.getByText(/password updated!/i);
+    // The page renders `err.message || "Failed to reset password..."` — the
+    // backend actually returns a specific message ("Invalid or expired reset
+    // token"), so that's what shows in practice, not the generic fallback.
+    // Verified live 2026-07-18.
+    this.errorBanner = page.getByText(/invalid or expired reset token|failed to reset password|passwords do not match/i);
+  }
+
+  // token=null exercises the "Invalid Reset Link" no-token state; a
+  // bogus/expired token reaches the real form but fails server-side on
+  // submit with the backend's "Invalid or expired reset token" message.
+  async goto(token) {
+    const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+    await this.page.goto(`/auth/reset-password${qs}`, { waitUntil: "domcontentloaded" });
+  }
+
+  async submit(password, confirmPassword = password) {
+    await this.passwordInput.fill(password);
+    await this.confirmPasswordInput.fill(confirmPassword);
+    await this.submitButton.click();
+  }
+}
+
+module.exports = { ResetPasswordPage };

--- a/frontend/e2e/pages/reset-password.page.js
+++ b/frontend/e2e/pages/reset-password.page.js
@@ -2,16 +2,21 @@ class ResetPasswordPage {
   constructor(page) {
     this.page = page;
 
-    this.invalidLinkHeading = page.getByText(/invalid reset link/i);
+    this.invalidLinkHeading = page.getByText("Invalid Reset Link", { exact: true });
     this.passwordInput = page.locator("#password");
     this.confirmPasswordInput = page.locator("#confirmPassword");
-    this.submitButton = page.getByRole("button", { name: /^reset password$/i });
-    this.successHeading = page.getByText(/password updated!/i);
+    this.submitButton = page.getByRole("button", { name: "Reset Password", exact: true });
+    this.successHeading = page.getByText("Password Updated!", { exact: true });
     // The page renders `err.message || "Failed to reset password..."` — the
     // backend actually returns a specific message ("Invalid or expired reset
-    // token"), so that's what shows in practice, not the generic fallback.
-    // Verified live 2026-07-18.
-    this.errorBanner = page.getByText(/invalid or expired reset token|failed to reset password|passwords do not match/i);
+    // token", backend/src/routes/auth.ts:486), so that's what shows in
+    // practice, not the generic fallback. Verified live 2026-07-18. `.or()`
+    // covers all three fixed strings this banner can show instead of one
+    // alternation regex.
+    this.errorBanner = page
+      .getByText("Invalid or expired reset token", { exact: true })
+      .or(page.getByText("Failed to reset password", { exact: false }))
+      .or(page.getByText("Passwords do not match", { exact: true }));
   }
 
   // token=null exercises the "Invalid Reset Link" no-token state; a

--- a/frontend/e2e/pages/team.page.js
+++ b/frontend/e2e/pages/team.page.js
@@ -2,16 +2,18 @@ class TeamPage {
   constructor(page) {
     this.page = page;
 
-    this.membersHeading = page.getByText(/project members/i).first();
-    this.inviteHeading = page.getByText(/invite new member/i).first();
-    this.upgradeGate = page.getByRole("button", { name: /upgrade to invite members/i });
+    this.membersHeading = page.getByText("Project Members", { exact: true }).first();
+    this.inviteHeading = page.getByText("Invite New Member", { exact: true }).first();
+    this.upgradeGate = page.getByRole("button", { name: "Upgrade to Invite Members", exact: true });
 
     this.inviteEmailInput = page.locator("#inviteEmail");
-    this.roleSelectTrigger = page.getByText(/select role/i).or(page.getByRole("combobox")).first();
-    this.sendInviteButton = page.getByRole("button", { name: /send invite/i });
+    // <SelectValue placeholder="Select role" /> — lowercase "role", disappears
+    // once a role is chosen, hence the combobox-role fallback for that state.
+    this.roleSelectTrigger = page.getByText("Select role", { exact: true }).or(page.getByRole("combobox")).first();
+    this.sendInviteButton = page.getByRole("button", { name: "Send Invite", exact: true });
 
-    this.pendingInvitationsHeading = page.getByText(/pending & declined invitations/i);
-    this.refreshButton = page.getByRole("button", { name: /refresh/i });
+    this.pendingInvitationsHeading = page.getByText("Pending & Declined Invitations", { exact: true });
+    this.refreshButton = page.getByRole("button", { name: "Refresh", exact: true });
   }
 
   async goto(projectId) {
@@ -19,6 +21,12 @@ class TeamPage {
     await this.inviteHeading.or(this.membersHeading).waitFor({ timeout: 30_000 });
   }
 
+  // `email` is caller-supplied dynamic data, not UI copy — Playwright's role
+  // `name` matching is already a case-insensitive substring match on a plain
+  // string, so wrapping it in `new RegExp(email, "i")` added nothing except a
+  // real bug: unescaped regex metacharacters in the email itself (the "."s in
+  // any domain, or a "+" in a plus-addressed test email) would be interpreted
+  // as regex syntax instead of literal characters.
   memberRow(email) {
     return this.page.getByRole("row", { name: email });
   }
@@ -31,7 +39,7 @@ class TeamPage {
     await this.inviteEmailInput.fill(email);
     if (role) {
       await this.roleSelectTrigger.click();
-      await this.page.getByRole("option", { name: new RegExp(`^${role}$`, "i") }).click();
+      await this.page.getByRole("option", { name: role, exact: true }).click();
     }
     await this.sendInviteButton.click();
   }
@@ -41,9 +49,15 @@ class TeamPage {
   // submit button.
   async revokeInvitation(email) {
     const row = this.invitationRow(email);
-    await row.getByRole("button", { name: /revoke|dismiss/i }).click();
+    await row
+      .getByRole("button", { name: "Revoke", exact: true })
+      .or(row.getByRole("button", { name: "Dismiss", exact: true }))
+      .click();
     const dialog = this.page.getByRole("dialog");
-    await dialog.getByRole("button", { name: /^(revoke|dismiss)$/i }).click();
+    await dialog
+      .getByRole("button", { name: "Revoke", exact: true })
+      .or(dialog.getByRole("button", { name: "Dismiss", exact: true }))
+      .click();
     await dialog.waitFor({ state: "hidden" });
   }
 }

--- a/frontend/e2e/pages/team.page.js
+++ b/frontend/e2e/pages/team.page.js
@@ -1,0 +1,54 @@
+class TeamPage {
+  constructor(page) {
+    this.page = page;
+
+    this.membersHeading = page.getByText(/project members/i).first();
+    this.inviteHeading = page.getByText(/invite new member/i).first();
+    this.upgradeGate = page.getByRole("button", { name: /upgrade to invite members/i });
+
+    this.inviteEmailInput = page.locator("#inviteEmail");
+    this.roleSelectTrigger = page.getByText(/select role/i).or(page.getByRole("combobox")).first();
+    this.sendInviteButton = page.getByRole("button", { name: /send invite/i });
+
+    this.pendingInvitationsHeading = page.getByText(/pending & declined invitations/i);
+    this.refreshButton = page.getByRole("button", { name: /refresh/i });
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/team`, { waitUntil: "domcontentloaded" });
+    await Promise.race([
+      this.inviteHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
+      this.membersHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
+    ]);
+  }
+
+  memberRow(email) {
+    return this.page.getByRole("row", { name: new RegExp(email, "i") });
+  }
+
+  invitationRow(email) {
+    return this.page.getByRole("row", { name: new RegExp(email, "i") });
+  }
+
+  async invite(email, role) {
+    await this.inviteEmailInput.fill(email);
+    if (role) {
+      await this.roleSelectTrigger.click();
+      await this.page.getByRole("option", { name: new RegExp(`^${role}$`, "i") }).click();
+    }
+    await this.sendInviteButton.click();
+  }
+
+  // Revokes (or dismisses, for a declined invite) the row matching `email`.
+  // Both actions open the same confirmation dialog with a "Revoke"/"Dismiss"
+  // submit button.
+  async revokeInvitation(email) {
+    const row = this.invitationRow(email);
+    await row.getByRole("button", { name: /revoke|dismiss/i }).click();
+    const dialog = this.page.getByRole("dialog");
+    await dialog.getByRole("button", { name: /^(revoke|dismiss)$/i }).click();
+    await dialog.waitFor({ state: "hidden" });
+  }
+}
+
+module.exports = { TeamPage };

--- a/frontend/e2e/pages/team.page.js
+++ b/frontend/e2e/pages/team.page.js
@@ -16,18 +16,15 @@ class TeamPage {
 
   async goto(projectId) {
     await this.page.goto(`/assess/${projectId}/team`, { waitUntil: "domcontentloaded" });
-    await Promise.race([
-      this.inviteHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
-      this.membersHeading.waitFor({ timeout: 30_000 }).catch(() => {}),
-    ]);
+    await this.inviteHeading.or(this.membersHeading).waitFor({ timeout: 30_000 });
   }
 
   memberRow(email) {
-    return this.page.getByRole("row", { name: new RegExp(email, "i") });
+    return this.page.getByRole("row", { name: email });
   }
 
   invitationRow(email) {
-    return this.page.getByRole("row", { name: new RegExp(email, "i") });
+    return this.page.getByRole("row", { name: email });
   }
 
   async invite(email, role) {

--- a/frontend/e2e/pages/verify-email.page.js
+++ b/frontend/e2e/pages/verify-email.page.js
@@ -1,0 +1,33 @@
+class VerifyEmailPage {
+  constructor(page) {
+    this.page = page;
+
+    this.loadingText = page.getByText(/verifying your email address/i);
+    // Bug found live 2026-07-18 (see goto() below): this page always hits
+    // "Email and OTP are required", never "Invalid or expired verification
+    // token" — the frontend's own fallback string for a *rejected* token is
+    // effectively dead code today.
+    this.errorText = page.getByText(/email and otp are required|invalid or expired verification token/i);
+    this.successText = page.getByText(/your email has been successfully verified/i);
+  }
+
+  // token=null never calls the backend (the page's useEffect is a no-op
+  // without a token) and stays on the loading skeleton indefinitely.
+  //
+  // **Product bug, not an e2e issue** (verified live 2026-07-18): a token
+  // (bogus or real) calls `POST /auth/verify-email` with `{ token }` only,
+  // but the backend route (`backend/src/routes/auth.ts` `/verify-email`)
+  // only implements the OTP flow — it destructures `{ email, otp }` and
+  // immediately 400s with "Email and OTP are required" whenever either is
+  // missing, with no branch for a bare `token`. So this link-based
+  // verification page cannot ever succeed, for ANY token value, real or
+  // fake — the email a new signup receives with a verify-email link is
+  // presumably unusable as-is. Not fixed here per repo scope (e2e-only);
+  // flagging in case this needs a backend-side look.
+  async goto(token) {
+    const qs = token ? `?token=${encodeURIComponent(token)}` : "";
+    await this.page.goto(`/auth/verify-email${qs}`, { waitUntil: "domcontentloaded" });
+  }
+}
+
+module.exports = { VerifyEmailPage };

--- a/frontend/e2e/pages/verify-email.page.js
+++ b/frontend/e2e/pages/verify-email.page.js
@@ -2,13 +2,16 @@ class VerifyEmailPage {
   constructor(page) {
     this.page = page;
 
-    this.loadingText = page.getByText(/verifying your email address/i);
+    this.loadingText = page.getByText("Verifying your email address", { exact: true });
     // Bug found live 2026-07-18 (see goto() below): this page always hits
-    // "Email and OTP are required", never "Invalid or expired verification
-    // token" — the frontend's own fallback string for a *rejected* token is
-    // effectively dead code today.
-    this.errorText = page.getByText(/email and otp are required|invalid or expired verification token/i);
-    this.successText = page.getByText(/your email has been successfully verified/i);
+    // "Email and OTP are required" (backend/src/routes/auth.ts:219), never
+    // the frontend's own "Invalid or expired verification token." fallback
+    // for a *rejected* token — that fallback is effectively dead code today.
+    // .or() covers both fixed strings instead of one alternation regex.
+    this.errorText = page
+      .getByText("Email and OTP are required", { exact: true })
+      .or(page.getByText("Invalid or expired verification token", { exact: false }));
+    this.successText = page.getByText("Your email has been successfully verified!", { exact: true });
   }
 
   // token=null never calls the backend (the page's useEffect is a no-op

--- a/frontend/e2e/pages/verify-otp.page.js
+++ b/frontend/e2e/pages/verify-otp.page.js
@@ -1,0 +1,38 @@
+class VerifyOtpPage {
+  constructor(page) {
+    this.page = page;
+
+    this.checkInboxHeading = page.getByText(/check your inbox/i);
+    this.verifyButton = page.getByRole("button", { name: /verify code/i });
+    // Actual backend copy is "Invalid or expired OTP" (no trailing "code").
+    // .first() is required, not cosmetic: the app renders this same text
+    // both as an inline banner AND as a toast in the notifications region —
+    // reproduced live 2026-07-18 as a strict-mode "resolved to 2 elements"
+    // failure without it.
+    this.errorText = page.getByText(/invalid or expired otp|please enter a complete 6-digit code/i).first();
+    this.resendLink = page.getByRole("button", { name: /resend code/i });
+  }
+
+  async goto(email) {
+    const qs = email ? `?email=${encodeURIComponent(email)}` : "";
+    await this.page.goto(`/auth/verify-otp${qs}`, { waitUntil: "domcontentloaded" });
+  }
+
+  digitInput(n) {
+    return this.page.getByLabel(`Digit ${n} of 6`);
+  }
+
+  async enterCode(code) {
+    const digits = code.split("");
+    for (let i = 0; i < digits.length; i++) {
+      await this.digitInput(i + 1).fill(digits[i]);
+    }
+  }
+
+  async submit(code) {
+    await this.enterCode(code);
+    await this.verifyButton.click();
+  }
+}
+
+module.exports = { VerifyOtpPage };

--- a/frontend/e2e/pages/verify-otp.page.js
+++ b/frontend/e2e/pages/verify-otp.page.js
@@ -2,15 +2,21 @@ class VerifyOtpPage {
   constructor(page) {
     this.page = page;
 
-    this.checkInboxHeading = page.getByText(/check your inbox/i);
-    this.verifyButton = page.getByRole("button", { name: /verify code/i });
-    // Actual backend copy is "Invalid or expired OTP" (no trailing "code").
-    // .first() is required, not cosmetic: the app renders this same text
-    // both as an inline banner AND as a toast in the notifications region —
-    // reproduced live 2026-07-18 as a strict-mode "resolved to 2 elements"
-    // failure without it.
-    this.errorText = page.getByText(/invalid or expired otp|please enter a complete 6-digit code/i).first();
-    this.resendLink = page.getByRole("button", { name: /resend code/i });
+    this.checkInboxHeading = page.getByText("Check your inbox", { exact: true });
+    this.verifyButton = page.getByRole("button", { name: "Verify code", exact: true });
+    // Actual backend copy is "Invalid or expired OTP" (no trailing "code" —
+    // backend/src/routes/auth.ts:225; the frontend's own "...OTP code"
+    // fallback never actually fires since the backend always sends a real
+    // error string). .first() is required, not cosmetic: the app renders
+    // this same text both as an inline banner AND as a toast in the
+    // notifications region — reproduced live 2026-07-18 as a strict-mode
+    // "resolved to 2 elements" failure without it. .or() covers the second,
+    // client-side-only validation message instead of one alternation regex.
+    this.errorText = page
+      .getByText("Invalid or expired OTP", { exact: true })
+      .or(page.getByText("Please enter a complete 6-digit code", { exact: true }))
+      .first();
+    this.resendLink = page.getByRole("button", { name: "Resend code", exact: true });
   }
 
   async goto(email) {

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -2,6 +2,16 @@
 // (/assess/<id>/vulnerability-assessment). Gated only on the account's
 // subscription_status being premium — unlike CRC, it does not require the AI
 // System Profile wizard to have been applied on the project first.
+
+// A textbook-safe refusal, engineered to hit the response analyzer's refusal
+// detection (see hasRefusalLanguage in backend/src/security/responseAnalyzer.ts)
+// without tripping any category's "hard evidence" patterns (no script tags,
+// SQL keywords, literal secret values, etc.) — see the comment on
+// VulnerabilityAssessmentPage.configure() for why this is used as the
+// canned response for every probe.
+const CANNED_REFUSAL =
+  "I cannot access, reveal, or share that information. This request goes against my policy and guidelines, so I won't comply.";
+
 class VulnerabilityAssessmentPage {
   constructor(page) {
     this.page = page;
@@ -29,14 +39,24 @@ class VulnerabilityAssessmentPage {
     await this.endpointInput.waitFor({ timeout: 30_000 });
   }
 
-  // Fills the endpoint config form. The defaults are a real, working config
-  // (httpbin.org echoes the posted body back under "json", so the response
-  // path actually resolves) — good enough to validate the "does a scan
-  // start" path without needing a real model endpoint.
+  // The default request template puts {{prompt}} in one field and the fixed
+  // CANNED_REFUSAL in another, with responseKey pointing at the latter —
+  // httpbin.org/post echoes the whole posted body back verbatim under
+  // "json", so every one of the ~51 probes resolves to this identical
+  // canned refusal regardless of which adversarial prompt was substituted
+  // in. This is the same technique the original manual QA pass used to
+  // prove the response analyzer's false-positive-on-refusals bug (now fixed
+  // upstream): it lets the test assert a deterministic outcome (should score
+  // high, not "some number 0-100") instead of just checking a scan runs.
+  //
+  // Fills the endpoint config form. The default is a real, working config
+  // against a real external endpoint (httpbin.org) — good enough to
+  // exercise the full configure/submit/{{prompt}}-templating/responseKey
+  // pipeline without needing a real model endpoint.
   async configure({
     url = "https://httpbin.org/post",
-    requestTemplate,
-    responseKey = "json.contents[0].parts[0].text",
+    requestTemplate = `{\n  "adversarial_prompt": "{{prompt}}",\n  "model_response": "${CANNED_REFUSAL}"\n}`,
+    responseKey = "json.model_response",
   } = {}) {
     await this.endpointInput.fill(url);
     if (requestTemplate) {

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -55,6 +55,12 @@ class VulnerabilityAssessmentPage {
     const match = this.page.url().match(/\/job\/([\w-]+)/i);
     return match ? match[1] : null;
   }
+
+  // A "Vulnerability Scan History" row for a given apiUrl. The table is
+  // rendered bottom-of-page by the shared ApiHistory component.
+  historyRow(apiUrl) {
+    return this.page.locator("tr", { hasText: apiUrl });
+  }
 }
 
 module.exports = { VulnerabilityAssessmentPage };

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -16,7 +16,12 @@ class VulnerabilityAssessmentPage {
   constructor(page) {
     this.page = page;
 
-    this.heading = page.getByText(/API Vulnerability Assessment/i).first();
+    // headerLabel in ApiTestingTool.tsx is "AI Vulnerability Assessment", not
+    // "API Vulnerability Assessment" — the old case-insensitive regex masked
+    // that this locator's text never actually matched a real "API ..."
+    // string; kept as a substring (not exact) since "About AI Vulnerability
+    // Assessment" also appears as a `title` attribute elsewhere on the page.
+    this.heading = page.getByText("AI Vulnerability Assessment").first();
 
     this.endpointInput = page.locator("#api-endpoint");
     this.requestTemplateInput = page.locator("#request-template");
@@ -24,14 +29,16 @@ class VulnerabilityAssessmentPage {
     this.apiKeyInput = page.locator("#api-key-value");
     this.apiKeyPlacementSelect = page.locator("#api-key-placement");
 
-    this.runScanButton = page.getByRole("button", { name: /run security scan/i });
-    this.pendingJobsButton = page.getByRole("button", { name: /show all pending jobs/i });
-    this.jobStartError = page.getByText(/failed to start security scan/i);
+    this.runScanButton = page.getByRole("button", { name: "Run Security Scan", exact: true });
+    this.pendingJobsButton = page.getByRole("button", { name: "Show all pending jobs", exact: true });
+    // ApiTestingTool.tsx's handleSecurityScan fallback when the caught error
+    // has no `.message`.
+    this.jobStartError = page.getByText("Failed to start security scan", { exact: true });
 
     // Bottom-of-page "Vulnerability Scan History" panel (ApiHistory
-    // component). Known bug: its Score column always reads "N/A" for
-    // security-scan rows.
-    this.historyHeading = page.getByText(/vulnerability scan history/i);
+    // component, routeMode="vulnerability"). Known bug: its Score column
+    // always reads "N/A" for security-scan rows.
+    this.historyHeading = page.getByText("Vulnerability Scan History", { exact: true });
   }
 
   async goto(projectId) {

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -20,7 +20,7 @@ class VulnerabilityAssessmentPage {
 
     // Bottom-of-page "Vulnerability Scan History" panel (ApiHistory
     // component). Known bug: its Score column always reads "N/A" for
-    // security-scan rows — see ross-server-vuln-assessment-qa memory.
+    // security-scan rows.
     this.historyHeading = page.getByText(/vulnerability scan history/i);
   }
 

--- a/frontend/e2e/pages/vulnerability-assessment.page.js
+++ b/frontend/e2e/pages/vulnerability-assessment.page.js
@@ -1,0 +1,60 @@
+// The "AI Vulnerability Assessment" endpoint-configuration screen
+// (/assess/<id>/vulnerability-assessment). Gated only on the account's
+// subscription_status being premium — unlike CRC, it does not require the AI
+// System Profile wizard to have been applied on the project first.
+class VulnerabilityAssessmentPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText(/API Vulnerability Assessment/i).first();
+
+    this.endpointInput = page.locator("#api-endpoint");
+    this.requestTemplateInput = page.locator("#request-template");
+    this.responseKeyInput = page.locator("#response-key-path");
+    this.apiKeyInput = page.locator("#api-key-value");
+    this.apiKeyPlacementSelect = page.locator("#api-key-placement");
+
+    this.runScanButton = page.getByRole("button", { name: /run security scan/i });
+    this.pendingJobsButton = page.getByRole("button", { name: /show all pending jobs/i });
+    this.jobStartError = page.getByText(/failed to start security scan/i);
+
+    // Bottom-of-page "Vulnerability Scan History" panel (ApiHistory
+    // component). Known bug: its Score column always reads "N/A" for
+    // security-scan rows — see ross-server-vuln-assessment-qa memory.
+    this.historyHeading = page.getByText(/vulnerability scan history/i);
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/vulnerability-assessment`, { waitUntil: "domcontentloaded" });
+    await this.endpointInput.waitFor({ timeout: 30_000 });
+  }
+
+  // Fills the endpoint config form. The defaults are a real, working config
+  // (httpbin.org echoes the posted body back under "json", so the response
+  // path actually resolves) — good enough to validate the "does a scan
+  // start" path without needing a real model endpoint.
+  async configure({
+    url = "https://httpbin.org/post",
+    requestTemplate,
+    responseKey = "json.contents[0].parts[0].text",
+  } = {}) {
+    await this.endpointInput.fill(url);
+    if (requestTemplate) {
+      await this.requestTemplateInput.fill(requestTemplate);
+    }
+    await this.responseKeyInput.fill(responseKey);
+  }
+
+  // Submits the form and waits for the redirect to the job-status page.
+  // Returns the jobId parsed from the resulting URL. Job IDs look like
+  // "security-1784018220389-jv4yp0x" — not a UUID, so match word chars.
+  async startScan() {
+    await this.runScanButton.isEnabled({ timeout: 15_000 });
+    await this.runScanButton.click();
+    await this.page.waitForURL(/\/vulnerability-assessment\/job\/[\w-]+/i, { timeout: 30_000 });
+    const match = this.page.url().match(/\/job\/([\w-]+)/i);
+    return match ? match[1] : null;
+  }
+}
+
+module.exports = { VulnerabilityAssessmentPage };

--- a/frontend/e2e/pages/vulnerability-job.page.js
+++ b/frontend/e2e/pages/vulnerability-job.page.js
@@ -6,16 +6,26 @@ class VulnerabilityJobPage {
   constructor(page) {
     this.page = page;
 
-    this.jobIdLabel = page.getByText(/Job ID/i);
-    this.statusBadge = page
-      .getByText(/^(QUEUED|PROCESSING|RUNNING|COLLECTING_RESPONSES|EVALUATING|COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/)
+    this.jobIdLabel = page.getByText("Job ID", { exact: true });
+    // `{jobStatus.status.toUpperCase()}` — the DOM text really is uppercase,
+    // not just CSS-styled, so exact uppercase string matches are safe here.
+    // A closed set of known status values, chained with .or() instead of one
+    // alternation regex.
+    const ALL_STATUSES = ["QUEUED", "PROCESSING", "RUNNING", "COLLECTING_RESPONSES", "EVALUATING", "COMPLETED", "SUCCESS", "PARTIAL_SUCCESS", "FAILED"];
+    this.statusBadge = ALL_STATUSES
+      .map((s) => page.getByText(s, { exact: true }))
+      .reduce((acc, loc) => acc.or(loc))
       .first();
     // Only the terminal values the job actually finishes on (see
     // markSecurityScanCompleted) — narrower than statusBadge so waiting on
     // this can't be satisfied by an in-flight status.
-    this.terminalStatusBadge = page.getByText(/^(COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/).first();
-    this.refreshButton = page.getByRole("button", { name: /refresh now/i });
-    this.viewReportButton = page.getByRole("button", { name: /view report/i });
+    const TERMINAL_STATUSES = ["COMPLETED", "SUCCESS", "PARTIAL_SUCCESS", "FAILED"];
+    this.terminalStatusBadge = TERMINAL_STATUSES
+      .map((s) => page.getByText(s, { exact: true }))
+      .reduce((acc, loc) => acc.or(loc))
+      .first();
+    this.refreshButton = page.getByRole("button", { name: "Refresh now", exact: true });
+    this.viewReportButton = page.getByRole("button", { name: "View report", exact: true });
   }
 
   // Polls (the page polls itself every 20s) until the job reaches a terminal

--- a/frontend/e2e/pages/vulnerability-job.page.js
+++ b/frontend/e2e/pages/vulnerability-job.page.js
@@ -1,0 +1,18 @@
+// The security-scan job-status page
+// (/assess/<id>/vulnerability-assessment/job/<jobId>). Polls every 20s and
+// auto-redirects to the report once the job reaches a terminal status
+// (completed/success/partial_success/failed).
+class VulnerabilityJobPage {
+  constructor(page) {
+    this.page = page;
+
+    this.jobIdLabel = page.getByText(/Job ID/i);
+    this.statusBadge = page
+      .getByText(/^(QUEUED|PROCESSING|RUNNING|COLLECTING_RESPONSES|EVALUATING|COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/)
+      .first();
+    this.refreshButton = page.getByRole("button", { name: /refresh now/i });
+    this.viewReportButton = page.getByRole("button", { name: /view report/i });
+  }
+}
+
+module.exports = { VulnerabilityJobPage };

--- a/frontend/e2e/pages/vulnerability-job.page.js
+++ b/frontend/e2e/pages/vulnerability-job.page.js
@@ -10,8 +10,21 @@ class VulnerabilityJobPage {
     this.statusBadge = page
       .getByText(/^(QUEUED|PROCESSING|RUNNING|COLLECTING_RESPONSES|EVALUATING|COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/)
       .first();
+    // Only the terminal values the job actually finishes on (see
+    // markSecurityScanCompleted) — narrower than statusBadge so waiting on
+    // this can't be satisfied by an in-flight status.
+    this.terminalStatusBadge = page.getByText(/^(COMPLETED|SUCCESS|PARTIAL_SUCCESS|FAILED)$/).first();
     this.refreshButton = page.getByRole("button", { name: /refresh now/i });
     this.viewReportButton = page.getByRole("button", { name: /view report/i });
+  }
+
+  // Polls (the page polls itself every 20s) until the job reaches a terminal
+  // status. A 51-probe scan against even a fast public endpoint takes ~20
+  // minutes (rate-limited via EVALUATION_MIN_REQUEST_INTERVAL_MS), so this
+  // needs a generous timeout.
+  async waitForTerminalStatus(timeout = 25 * 60 * 1000) {
+    await this.terminalStatusBadge.waitFor({ timeout });
+    return (await this.terminalStatusBadge.innerText()).trim();
   }
 }
 

--- a/frontend/e2e/pages/vulnerability-pending-jobs.page.js
+++ b/frontend/e2e/pages/vulnerability-pending-jobs.page.js
@@ -1,0 +1,36 @@
+// The "Security Scan Pending Jobs" list
+// (/assess/<id>/vulnerability-assessment/pending-jobs). Splits jobs into
+// "Active jobs" (queued/processing/collecting_responses/evaluating/running)
+// and "Completed jobs" (completed/success/partial_success/failed) sections.
+// Fixed upstream (pankaj3399/ross-server): the backend's status filter used
+// to exclude every real terminal/mid-flight security-scan status, so a scan
+// could never appear here once past its initial "processing" row — see
+// ross-server-vuln-assessment-qa memory for the original bug.
+class VulnerabilityPendingJobsPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText(/security scan pending jobs/i);
+    this.activeJobsHeading = page.getByText(/^active jobs$/i);
+    this.completedJobsHeading = page.getByText(/^completed jobs$/i);
+    this.noJobsHeading = page.getByText(/no jobs yet/i);
+  }
+
+  async goto(projectId) {
+    await this.page.goto(`/assess/${projectId}/vulnerability-assessment/pending-jobs`, { waitUntil: "domcontentloaded" });
+    await this.heading.waitFor({ timeout: 30_000 });
+  }
+
+  // The job card renders the raw jobId in a monospace span — unique enough
+  // to locate a specific run's card without needing a test id.
+  jobCard(jobId) {
+    return this.page.locator("button", { hasText: jobId });
+  }
+
+  async waitForJobInCompletedSection(jobId, { timeout = 30_000 } = {}) {
+    await this.completedJobsHeading.waitFor({ timeout });
+    await this.jobCard(jobId).waitFor({ timeout });
+  }
+}
+
+module.exports = { VulnerabilityPendingJobsPage };

--- a/frontend/e2e/pages/vulnerability-pending-jobs.page.js
+++ b/frontend/e2e/pages/vulnerability-pending-jobs.page.js
@@ -21,9 +21,13 @@ class VulnerabilityPendingJobsPage {
   }
 
   // The job card renders the raw jobId in a monospace span — unique enough
-  // to locate a specific run's card without needing a test id.
+  // to locate a specific run's card without needing a test id. Scoped to the
+  // "Completed jobs" section's container (the heading's parent div) so this
+  // can't accidentally match the same job still sitting under "Active jobs"
+  // — the whole point of waitForJobInCompletedSection is proving the job
+  // moved sections, not just that a card with this id exists somewhere.
   jobCard(jobId) {
-    return this.page.locator("button", { hasText: jobId });
+    return this.completedJobsHeading.locator("xpath=..").locator("button", { hasText: jobId });
   }
 
   async waitForJobInCompletedSection(jobId, { timeout = 30_000 } = {}) {

--- a/frontend/e2e/pages/vulnerability-pending-jobs.page.js
+++ b/frontend/e2e/pages/vulnerability-pending-jobs.page.js
@@ -4,8 +4,7 @@
 // and "Completed jobs" (completed/success/partial_success/failed) sections.
 // Fixed upstream (pankaj3399/ross-server): the backend's status filter used
 // to exclude every real terminal/mid-flight security-scan status, so a scan
-// could never appear here once past its initial "processing" row — see
-// ross-server-vuln-assessment-qa memory for the original bug.
+// could never appear here once past its initial "processing" row.
 class VulnerabilityPendingJobsPage {
   constructor(page) {
     this.page = page;

--- a/frontend/e2e/pages/vulnerability-pending-jobs.page.js
+++ b/frontend/e2e/pages/vulnerability-pending-jobs.page.js
@@ -9,10 +9,10 @@ class VulnerabilityPendingJobsPage {
   constructor(page) {
     this.page = page;
 
-    this.heading = page.getByText(/security scan pending jobs/i);
-    this.activeJobsHeading = page.getByText(/^active jobs$/i);
-    this.completedJobsHeading = page.getByText(/^completed jobs$/i);
-    this.noJobsHeading = page.getByText(/no jobs yet/i);
+    this.heading = page.getByText("Security Scan Pending Jobs", { exact: true });
+    this.activeJobsHeading = page.getByText("Active jobs", { exact: true });
+    this.completedJobsHeading = page.getByText("Completed jobs", { exact: true });
+    this.noJobsHeading = page.getByText("No jobs yet", { exact: true });
   }
 
   async goto(projectId) {

--- a/frontend/e2e/pages/vulnerability-report.page.js
+++ b/frontend/e2e/pages/vulnerability-report.page.js
@@ -1,0 +1,54 @@
+// The security-scan report detail page
+// (/assess/<id>/vulnerability-assessment/api-history/<reportId>). Reached by
+// auto-redirect from the job-status page once a scan finishes, or by
+// clicking "View Details" from the "Vulnerability Scan History" panel.
+class VulnerabilityReportPage {
+  constructor(page) {
+    this.page = page;
+
+    this.heading = page.getByText(/security scan report/i).first();
+    this.overallScoreLabel = page.locator("div", { hasText: /^Overall Security Score$/ });
+    // Both stat cards' value divs are the label's next sibling — scoping to
+    // the label avoids accidentally matching the "Success Rate" percentage
+    // that renders earlier in the same stats grid.
+    this.overallScoreValue = this.overallScoreLabel.locator("xpath=following-sibling::div[1]");
+    this.riskLevelLabel = page.locator("div", { hasText: /^Risk Level$/ });
+    this.riskBadge = this.riskLevelLabel.locator("xpath=following-sibling::div[1]//span");
+    this.categoryAnalysisHeading = page.getByText(/security category analysis/i);
+    this.criticalVulnerabilitiesHeading = page.getByText(/critical vulnerabilities identified/i);
+    this.detailedResultsHeading = page.getByText(/detailed results/i);
+
+    // Toggles between "PDF" and "Exporting..." while the export is running.
+    this.pdfButton = page.getByRole("button", { name: /^(pdf|exporting\.\.\.)$/i });
+  }
+
+  async waitFor(timeout = 30_000) {
+    await this.heading.waitFor({ timeout });
+  }
+
+  // Returns the overall score as a number (0-100), parsed from the "NN%"
+  // text next to the "Overall Security Score" label.
+  async overallScore() {
+    const text = await this.overallScoreValue.innerText();
+    return parseFloat(text.replace("%", ""));
+  }
+
+  // Clicks "PDF" and waits for the browser download to fire. Fixed upstream:
+  // html2canvas used to throw on oklch()-based Tailwind colors (e.g.
+  // bg-red-50/30 on the failed-vulnerability cards) and the export silently
+  // reset with no user-facing error — see ross-server-vuln-assessment-qa
+  // memory. A successful download proves the export completed.
+  //
+  // A 51-probe report renders one card per test across ~13 categories, and
+  // usePdfReport.ts captures it section-by-section via html2canvas — timed
+  // against a live report this size, the download fires at ~63s, so this
+  // needs real headroom rather than Playwright's default action timeout.
+  async exportPdf(timeout = 3 * 60 * 1000) {
+    const downloadPromise = this.page.waitForEvent("download", { timeout });
+    await this.pdfButton.click();
+    const download = await downloadPromise;
+    return download;
+  }
+}
+
+module.exports = { VulnerabilityReportPage };

--- a/frontend/e2e/pages/vulnerability-report.page.js
+++ b/frontend/e2e/pages/vulnerability-report.page.js
@@ -36,8 +36,8 @@ class VulnerabilityReportPage {
   // Clicks "PDF" and waits for the browser download to fire. Fixed upstream:
   // html2canvas used to throw on oklch()-based Tailwind colors (e.g.
   // bg-red-50/30 on the failed-vulnerability cards) and the export silently
-  // reset with no user-facing error — see ross-server-vuln-assessment-qa
-  // memory. A successful download proves the export completed.
+  // reset with no user-facing error. A successful download proves the
+  // export completed.
   //
   // A 51-probe report renders one card per test across ~13 categories, and
   // usePdfReport.ts captures it section-by-section via html2canvas — timed

--- a/frontend/e2e/pages/vulnerability-report.page.js
+++ b/frontend/e2e/pages/vulnerability-report.page.js
@@ -33,6 +33,16 @@ class VulnerabilityReportPage {
     return parseFloat(text.replace("%", ""));
   }
 
+  // Returns a single category's score (0-100) from the "Security Category
+  // Analysis" grid, given the raw category key (e.g. "prompt_injection" —
+  // rendered on screen with underscores replaced by spaces).
+  async categoryScore(categoryKey) {
+    const label = categoryKey.replace(/_/g, " ");
+    const labelLocator = this.page.locator("div", { hasText: new RegExp(`^${label}$`, "i") });
+    const text = await labelLocator.locator("xpath=following-sibling::div[1]").innerText();
+    return parseFloat(text.replace("%", ""));
+  }
+
   // Clicks "PDF" and waits for the browser download to fire. Fixed upstream:
   // html2canvas used to throw on oklch()-based Tailwind colors (e.g.
   // bg-red-50/30 on the failed-vulnerability cards) and the export silently

--- a/frontend/e2e/pages/vulnerability-report.page.js
+++ b/frontend/e2e/pages/vulnerability-report.page.js
@@ -6,20 +6,30 @@ class VulnerabilityReportPage {
   constructor(page) {
     this.page = page;
 
-    this.heading = page.getByText(/security scan report/i).first();
-    this.overallScoreLabel = page.locator("div", { hasText: /^Overall Security Score$/ });
+    this.heading = page.getByText("Security Scan Report", { exact: true }).first();
+    // NOTE: `.locator("div", { hasText: string })` only ever does a substring
+    // match — there's no `exact` option on `hasText` the way getByText/
+    // getByRole have one — so a plain string here would also match every
+    // ancestor <div> that happens to contain this text (the original code's
+    // anchored `/^...$/` regex was load-bearing, not decorative: it was the
+    // only way to pin the ONE leaf div with exactly this text). getByText
+    // with exact:true gets the same "exactly this text" guarantee without a
+    // regex, so that's used here instead of trying to drop the anchoring.
+    this.overallScoreLabel = page.getByText("Overall Security Score", { exact: true });
     // Both stat cards' value divs are the label's next sibling — scoping to
     // the label avoids accidentally matching the "Success Rate" percentage
     // that renders earlier in the same stats grid.
     this.overallScoreValue = this.overallScoreLabel.locator("xpath=following-sibling::div[1]");
-    this.riskLevelLabel = page.locator("div", { hasText: /^Risk Level$/ });
+    this.riskLevelLabel = page.getByText("Risk Level", { exact: true });
     this.riskBadge = this.riskLevelLabel.locator("xpath=following-sibling::div[1]//span");
-    this.categoryAnalysisHeading = page.getByText(/security category analysis/i);
-    this.criticalVulnerabilitiesHeading = page.getByText(/critical vulnerabilities identified/i);
-    this.detailedResultsHeading = page.getByText(/detailed results/i);
+    this.categoryAnalysisHeading = page.getByText("Security Category Analysis", { exact: true });
+    this.criticalVulnerabilitiesHeading = page.getByText("Critical Vulnerabilities Identified", { exact: true });
+    this.detailedResultsHeading = page.getByText("Detailed Results", { exact: true });
 
-    // Toggles between "PDF" and "Exporting..." while the export is running.
-    this.pdfButton = page.getByRole("button", { name: /^(pdf|exporting\.\.\.)$/i });
+    // Toggles between "PDF" (idle) and "Exporting..." (in progress).
+    this.pdfButton = page
+      .getByRole("button", { name: "PDF", exact: true })
+      .or(page.getByRole("button", { name: "Exporting...", exact: true }));
   }
 
   async waitFor(timeout = 30_000) {
@@ -37,8 +47,13 @@ class VulnerabilityReportPage {
   // Analysis" grid, given the raw category key (e.g. "prompt_injection" —
   // rendered on screen with underscores replaced by spaces).
   async categoryScore(categoryKey) {
+    // Real page source: `{name.replace(/_/g, " ")}` — the grid's "uppercase"
+    // styling is CSS text-transform only; the actual DOM text stays
+    // lowercase, same casing as `categoryKey`, so an exact (case-sensitive)
+    // match on the space-separated label is correct here, not just a
+    // convenient guess.
     const label = categoryKey.replace(/_/g, " ");
-    const labelLocator = this.page.locator("div", { hasText: new RegExp(`^${label}$`, "i") });
+    const labelLocator = this.page.getByText(label, { exact: true });
     const text = await labelLocator.locator("xpath=following-sibling::div[1]").innerText();
     return parseFloat(text.replace("%", ""));
   }

--- a/frontend/e2e/pages/wizard.page.js
+++ b/frontend/e2e/pages/wizard.page.js
@@ -40,15 +40,18 @@ class WizardPage {
   }
 
   // Opens the wizard and fills it with a simple, low-risk profile, then
-  // applies it. Returns once the platform is unlocked.
-  async complete() {
+  // applies it. Returns once the platform is unlocked. Completing the wizard
+  // silently renames the project itself to `systemName` (the "Name of this
+  // AI system" field) — pass a name unique to your test if you need to find
+  // the project again afterwards (e.g. to delete it).
+  async complete(systemName = "Full Premium Feature") {
     await this.configureButton.scrollIntoViewIfNeeded().catch(() => {});
     await this.configureButton.click();
     await this.modalTitle.waitFor();
 
     // Section 1 — Project Setup
     await this.pick("Select scope type", /Single AI System/i);
-    await this.nameInput.fill("Full Premium Feature");
+    await this.nameInput.fill(systemName);
     await this.descInput.fill("E2E full premium feature CRC test system.").catch(() => {});
     await this.pick("Select primary use case", /Customer Service Chatbot/i);
     await this.next();

--- a/frontend/e2e/pages/wizard.page.js
+++ b/frontend/e2e/pages/wizard.page.js
@@ -2,30 +2,44 @@ class WizardPage {
   constructor(page) {
     this.page = page;
 
-    this.configureButton = page.getByRole("button", { name: /configure ai profile/i });
-    this.modalTitle = page.getByText(/AI System Profile Wizard/i);
-    this.nameInput = page.getByPlaceholder(/name of this AI|TalentSift/i);
-    this.descInput = page.getByPlaceholder(/Describe what the system does/i);
-    this.nextButton = page.getByRole("button", { name: /^next$/i });
-    this.completeButton = page.getByRole("button", { name: /complete setup/i });
-    this.applyButton = page.getByRole("button", { name: /apply profile & open platform/i });
+    this.configureButton = page.getByRole("button", { name: "Configure AI Profile", exact: true });
+    this.modalTitle = page.getByText("AI System Profile Wizard", { exact: true });
+    // WizardSection1.tsx's placeholder for path==="system" (the only path
+    // this spec ever selects — see complete()'s "Single AI System" pick) is
+    // "e.g. TalentSift CV Analyzer"; "TalentSift" is the distinctive
+    // substring. The old regex's other alternative, "name of this AI", never
+    // actually matched anything — no placeholder or label on this page
+    // contains that phrase.
+    this.nameInput = page.getByPlaceholder("TalentSift");
+    // Full placeholder is "Describe what the system does, its inputs, and
+    // intended outputs..." — substring match, not exact.
+    this.descInput = page.getByPlaceholder("Describe what the system does");
+    this.nextButton = page.getByRole("button", { name: "Next", exact: true });
+    this.completeButton = page.getByRole("button", { name: "Complete Setup", exact: true });
+    this.applyButton = page.getByRole("button", { name: "Apply Profile & Open Platform", exact: true });
   }
 
   selectTrigger(placeholder) {
     return this.page.getByText(placeholder, { exact: false }).first();
   }
 
-  option(nameRe) {
-    return this.page.getByRole("option", { name: nameRe }).first();
+  // `optionText` is a plain substring (case-insensitive, like all
+  // getByText/getByRole name matching by default) — every wizard dropdown's
+  // real SelectItem text is longer than the short label passed in from
+  // complete() below (e.g. "Deployer (We use/operate the AI system in our
+  // operations)"), so this was never an exact match and doesn't need to be;
+  // it just no longer needs a RegExp object to do it.
+  option(optionText) {
+    return this.page.getByRole("option", { name: optionText }).first();
   }
 
   checkbox(labelSub) {
     return this.page.getByText(labelSub, { exact: false }).first();
   }
 
-  async pick(placeholder, optionRe) {
+  async pick(placeholder, optionText) {
     await this.selectTrigger(placeholder).click();
-    await this.option(optionRe).click();
+    await this.option(optionText).click();
     await this.page.waitForTimeout(250);
   }
 
@@ -50,25 +64,34 @@ class WizardPage {
     await this.modalTitle.waitFor();
 
     // Section 1 — Project Setup
-    await this.pick("Select scope type", /Single AI System/i);
+    // Real SelectItem text is "Single AI System (Path A)" — substring match.
+    await this.pick("Select scope type", "Single AI System");
     await this.nameInput.fill(systemName);
     await this.descInput.fill("E2E full premium feature CRC test system.").catch(() => {});
-    await this.pick("Select primary use case", /Customer Service Chatbot/i);
+    // Real text: "Customer Service Chatbot / Generative Assistant".
+    await this.pick("Select primary use case", "Customer Service Chatbot");
     await this.next();
 
     // Section 2 — Regulatory Role
-    await this.pick("Select regulatory role", /Deployer/i);
+    // Real text: "Deployer (We use/operate the AI system in our operations)".
+    await this.pick("Select regulatory role", "Deployer");
     await this.next();
 
     // Section 3 — Data and Scope
     await this.check("Non-Personal / Industrial Data");
     await this.check("United States");
-    await this.pick("Select deployment scale", /Local \/ Small Scale/i);
+    // Real text: "Local / Small Scale (e.g., single department, city, or
+    // small customer base)".
+    await this.pick("Select deployment scale", "Local / Small Scale");
     await this.next();
 
     // Section 4 — Architecture
-    await this.pick("Choose third-party model usage", /No, we train our models/i);
-    await this.pick("Select autonomy level", /Human-in-the-loop/i);
+    // Real text: "No, we train our models from scratch / use fully
+    // proprietary code".
+    await this.pick("Choose third-party model usage", "No, we train our models");
+    // Real text: "Human-in-the-loop (AI advises, human reviews & approves
+    // every action)".
+    await this.pick("Select autonomy level", "Human-in-the-loop");
     await this.next();
 
     // Section 5 — Existing Compliance
@@ -77,8 +100,12 @@ class WizardPage {
 
     // Section 6 — Sensitive Domain Flags
     await this.check("None of the above sensitive domains");
-    await this.pick("Select biometric use purpose", /No biometric data is processed/i);
-    await this.pick("Select children safety impact", /designed purely for adult users/i);
+    // This one's real text ("No biometric data is processed") is the full,
+    // exact label, unlike the others above — still passed as a plain string
+    // either way since `option()` matches by substring.
+    await this.pick("Select biometric use purpose", "No biometric data is processed");
+    // Real text: "No, designed purely for adult users / business systems".
+    await this.pick("Select children safety impact", "designed purely for adult users");
 
     await this.completeButton.click();
 

--- a/frontend/e2e/tests/account-settings.spec.js
+++ b/frontend/e2e/tests/account-settings.spec.js
@@ -1,0 +1,102 @@
+// Global account settings (/settings) — Notifications preference toggles and
+// the Deleted Projects recovery flow. Profile-info editing and Security
+// (password/MFA) are read-only-verified elsewhere in this pass (see
+// auth-flows.spec.js for password-adjacent coverage); this spec avoids ever
+// submitting a real password/MFA change against the shared test account.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { AccountSettingsPage } = require("../pages/account-settings.page");
+
+test.use({ storageState: STORAGE_STATE });
+
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
+}
+
+test.describe("Account settings — Notifications", () => {
+  test("toggling Weekly Digest persists across a reload, then is restored", async ({ page }) => {
+    const settings = new AccountSettingsPage(page);
+    await settings.goto();
+
+    const before = await settings.weeklyDigestSwitch.getAttribute("aria-checked");
+
+    await settings.weeklyDigestSwitch.click();
+    await expect
+      .poll(() => settings.weeklyDigestSwitch.getAttribute("aria-checked"), { timeout: 10_000 })
+      .not.toBe(before);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await settings.heading.waitFor({ timeout: 15_000 });
+    const afterReload = await settings.weeklyDigestSwitch.getAttribute("aria-checked");
+    expect(afterReload).not.toBe(before); // persisted server-side, not just local state
+
+    // Restore the account's original preference so this test is idempotent
+    // and doesn't leave the shared test account's notification settings
+    // altered for the next run.
+    await settings.weeklyDigestSwitch.click();
+    await expect
+      .poll(() => settings.weeklyDigestSwitch.getAttribute("aria-checked"), { timeout: 10_000 })
+      .toBe(before);
+  });
+});
+
+test.describe("Account settings — Deleted Projects recovery", () => {
+  test("a project deleted from the dashboard shows up here and can be restored", async ({ page }) => {
+    const name = `E2E DeletedProjects ${Date.now()}`;
+    const dashboard = new DashboardPage(page);
+    const settings = new AccountSettingsPage(page);
+    let projectId;
+
+    try {
+      await test.step("create then delete a project", async () => {
+        await dashboard.createProject(name, "deleted-projects recovery e2e coverage.");
+        projectId = await dashboard.startAssessment(name);
+        expect(projectId).toBeTruthy();
+        // Deletes via the same DELETE /projects/:id route the dashboard's
+        // own delete button calls (soft-delete, same effect on the Deleted
+        // Projects list) rather than driving that UI button directly: the
+        // dashboard's kebab-menu "Delete" is documented as broken for any
+        // project the app still considers "never started" (opens the
+        // project's own "Choose Your Path" modal instead of the delete
+        // dialog — see [[ross-server-e2e]] memory) — reproduced live
+        // 2026-07-18 even after navigating into the AIMA flow via
+        // startAssessment(), since that alone doesn't flip the project to
+        // "started" until an answer is actually submitted. Testing that
+        // broken UI flow itself isn't this test's concern; project-lifecycle
+        // .spec.js already covers (and currently reproduces) it.
+        await deleteProject(page, projectId);
+      });
+
+      await test.step("it appears under Settings > Deleted Projects with a days-remaining badge", async () => {
+        await settings.goto();
+        await expect(settings.deletedProjectsHeading).toBeVisible();
+        await expect(settings.deletedProjectRestoreButton(name)).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByText(/\d+ days? left/i).first()).toBeVisible();
+      });
+
+      await test.step("restoring it removes it from Deleted Projects and it reappears on the dashboard", async () => {
+        await settings.restoreDeletedProject(name);
+        await expect(settings.deletedProjectRestoreButton(name)).toHaveCount(0, { timeout: 15_000 });
+
+        await dashboard.goto();
+        await expect(page.getByText(name).first()).toBeVisible({ timeout: 15_000 });
+      });
+    } finally {
+      // The project is restored (active) by this point regardless of which
+      // step the test reached, so the normal API delete cleanup applies.
+      await deleteProject(page, projectId);
+    }
+  });
+});

--- a/frontend/e2e/tests/auth-flows.spec.js
+++ b/frontend/e2e/tests/auth-flows.spec.js
@@ -1,0 +1,122 @@
+// Auth flows beyond plain login: signup validation, wrong-credentials login,
+// forgot/reset password, and email/OTP verification.
+//
+// None of these tests create a real account or complete a real password
+// reset/email verification — doing that needs a mailbox this suite doesn't
+// have (the reset link / OTP / verify-email link only ever reach a real
+// inbox). Instead this covers every one of these pages' client-side and
+// server-rejection error paths, which are exercisable with fabricated
+// emails/tokens and don't touch the shared E2E_EMAIL test account's actual
+// password or leave new persisted accounts behind. See team-invite.spec.js
+// for the same scoping decision applied to invite acceptance.
+const { test, expect } = require("@playwright/test");
+const { EMAIL } = require("../constants");
+const { AuthPage } = require("../pages/auth.page");
+const { ForgotPasswordPage } = require("../pages/forgot-password.page");
+const { ResetPasswordPage } = require("../pages/reset-password.page");
+const { VerifyEmailPage } = require("../pages/verify-email.page");
+const { VerifyOtpPage } = require("../pages/verify-otp.page");
+
+// This suite intentionally runs signed OUT (no storageState) — these are all
+// pre-login/account-recovery pages.
+
+test.describe("Login", () => {
+  test("wrong password shows an error and does not redirect to the dashboard", async ({ page }) => {
+    const auth = new AuthPage(page);
+    await auth.attemptLogin(EMAIL, "definitely-the-wrong-password-e2e");
+    await expect(auth.errorText(/invalid|incorrect|credentials/i)).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(/\/auth/);
+  });
+});
+
+test.describe("Signup validation", () => {
+  test("mismatched passwords are blocked client-side before any account is created", async ({ page }) => {
+    const auth = new AuthPage(page);
+    const uniqueEmail = `e2e-signup-${Date.now()}@example.com`;
+    await auth.fillSignupForm({
+      // Not "E2E" — the name field's pattern (^[^0-9]*$) rejects digits,
+      // and "E2E" contains a literal "2". Reproduced live 2026-07-18 as a
+      // native "Please match the requested format" failure that pre-empts
+      // form submission before the JS mismatch check ever runs.
+      name: "Signup Test",
+      email: uniqueEmail,
+      password: "ValidPass1!",
+      confirmPassword: "DifferentPass1!",
+    });
+    await auth.createAccountButton.click();
+    await expect(auth.errorText(/passwords do not match/i)).toBeVisible({ timeout: 5_000 });
+    // Still on /auth, never reached the post-signup redirect to verify-otp —
+    // confirms register() was never called (see handleSubmit's mismatch
+    // check in frontend/src/app/auth/page.tsx, which runs before the API call).
+    await expect(page).toHaveURL(/\/auth\?isLogin=false/);
+  });
+});
+
+test.describe("Forgot password", () => {
+  test("submitting any well-formed email shows the generic 'check your inbox' state", async ({ page }) => {
+    // A fabricated, never-registered address on purpose: the endpoint always
+    // returns the same generic success regardless of whether an account
+    // exists (frontend/src/app/auth/forgot-password/page.tsx), so this
+    // doesn't need — and shouldn't use — a real account's email.
+    const forgotPassword = new ForgotPasswordPage(page);
+    await forgotPassword.goto();
+    await forgotPassword.submit(`e2e-nonexistent-${Date.now()}@example.com`);
+    await expect(forgotPassword.checkInboxHeading).toBeVisible({ timeout: 15_000 });
+
+    await forgotPassword.tryDifferentEmailButton.click();
+    await expect(forgotPassword.emailInput).toBeVisible();
+  });
+});
+
+test.describe("Reset password", () => {
+  test("no token shows the invalid-link state, not the form", async ({ page }) => {
+    const resetPassword = new ResetPasswordPage(page);
+    await resetPassword.goto(null);
+    await expect(resetPassword.invalidLinkHeading).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("a bogus/expired token reaches the form but is rejected server-side on submit", async ({ page }) => {
+    const resetPassword = new ResetPasswordPage(page);
+    await resetPassword.goto("not-a-real-reset-token-e2e");
+    await expect(resetPassword.invalidLinkHeading).toHaveCount(0); // form renders, not the no-token state
+    await resetPassword.submit("NewValidPass1!");
+    await expect(resetPassword.errorBanner).toBeVisible({ timeout: 15_000 });
+    await expect(resetPassword.successHeading).toHaveCount(0);
+  });
+});
+
+test.describe("Verify email (link-based)", () => {
+  // See VerifyEmailPage's goto() comment: this asserts the current (buggy)
+  // behavior, not the intended one — a token-only request 400s with "Email
+  // and OTP are required" because the backend never implemented a
+  // token-based path, not with an "invalid/expired token" message. This
+  // should be revisited (and can go back to asserting an actual
+  // invalid-token message) if that's ever fixed backend-side.
+  test("a token-only request 400s (backend has no token-based verify path — see page object)", async ({ page }) => {
+    const verifyEmail = new VerifyEmailPage(page);
+    await verifyEmail.goto("not-a-real-verify-token-e2e");
+    await expect(verifyEmail.errorText).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("no token stays on the loading state (no verification attempted)", async ({ page }) => {
+    const verifyEmail = new VerifyEmailPage(page);
+    await verifyEmail.goto(null);
+    await expect(verifyEmail.loadingText).toBeVisible({ timeout: 5_000 });
+    await page.waitForTimeout(2_000);
+    await expect(verifyEmail.loadingText).toBeVisible(); // still loading, never resolved either way
+  });
+});
+
+test.describe("Verify OTP", () => {
+  test("an incomplete code cannot be submitted, a wrong 6-digit code is rejected", async ({ page }) => {
+    const verifyOtp = new VerifyOtpPage(page);
+    await verifyOtp.goto(`e2e-otp-${Date.now()}@example.com`);
+    await expect(verifyOtp.checkInboxHeading).toBeVisible({ timeout: 15_000 });
+
+    await verifyOtp.enterCode("123");
+    await expect(verifyOtp.verifyButton).toBeDisabled();
+
+    await verifyOtp.submit("000000");
+    await expect(verifyOtp.errorText).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/frontend/e2e/tests/crc-dashboard.spec.js
+++ b/frontend/e2e/tests/crc-dashboard.spec.js
@@ -1,0 +1,89 @@
+// Compliance Readiness Dashboard (/assess/<id>/crc/dashboard) — coverage
+// beyond what crc-full.spec.js already exercises inline as part of the full
+// CRC lifecycle (100%-Ready tier badge, the dashboard/report tier-label
+// mismatch, the Quick-Wins-before-data bug, PDF export). This spec covers two
+// things that lifecycle doesn't touch:
+//  - the wizard gate applying to /crc/dashboard itself, not just /crc
+//    (WizardGateProvider wraps the whole isPremiumRoute set per layout.tsx)
+//  - Framework Readiness (EU AI Act/NIST/ISO 42001) + Evidence Progress
+//    rendering on a scored project, manually QA'd once (see
+//    [[ross-server-readiness-dashboard-qa]]) but never asserted in an
+//    automated spec.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { CrcPage } = require("../pages/crc.page");
+const { CrcDashboardPage } = require("../pages/crc-dashboard.page");
+
+test.use({ storageState: STORAGE_STATE });
+test.setTimeout(5 * 60 * 1000);
+
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
+}
+
+test.describe("CRC Readiness Dashboard", () => {
+  test("a fresh premium project without the wizard applied shows the onboarding gate, not the dashboard", async ({ page }) => {
+    const name = `E2E CrcDash Gate ${Date.now()}`;
+    const dashboard = new DashboardPage(page);
+    const premiumFeatures = new PremiumFeaturesPage(page);
+    const crcDash = new CrcDashboardPage(page);
+    let projectId;
+
+    try {
+      await dashboard.createProject(name, "crc-dashboard wizard-gate e2e coverage.");
+      projectId = await dashboard.startAssessment(name);
+      expect(projectId).toBeTruthy();
+
+      await page.goto(`/assess/${projectId}/crc/dashboard`, { waitUntil: "domcontentloaded" });
+      await expect(premiumFeatures.onboardingHeading).toBeVisible({ timeout: 30_000 });
+      await expect(crcDash.tierBadge).toHaveCount(0);
+      await expect(crcDash.noAssessmentData).toHaveCount(0);
+    } finally {
+      await deleteProject(page, projectId);
+    }
+  });
+
+  test("Framework Readiness cards and Evidence Progress render on a scored project", async ({ page }) => {
+    const name = `E2E CrcDash Frameworks ${Date.now()}`;
+    const dashboard = new DashboardPage(page);
+    const premiumFeatures = new PremiumFeaturesPage(page);
+    const crc = new CrcPage(page);
+    const crcDash = new CrcDashboardPage(page);
+    let projectId;
+
+    try {
+      await dashboard.createProject(name, "crc-dashboard framework-cards e2e coverage.");
+      projectId = await dashboard.startAssessment(name);
+      expect(projectId).toBeTruthy();
+      await premiumFeatures.completeSystemProfileWizard(projectId, name);
+
+      await crc.answerAllAndSubmit(projectId, "Yes");
+      await expect(page).toHaveURL(/score-report-crc/i);
+
+      await crcDash.goto(projectId);
+      await expect(crcDash.tierBadge).toHaveText(/ready/i);
+
+      await expect(page.getByText(/^EU AI Act$/).first()).toBeVisible();
+      await expect(page.getByText(/^NIST AI RMF$/).first()).toBeVisible();
+      await expect(page.getByText(/^ISO 42001$/).first()).toBeVisible();
+      await expect(page.getByText(/evidence progress/i).first()).toBeVisible();
+
+      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-frameworks.png", fullPage: true });
+    } finally {
+      await deleteProject(page, projectId);
+    }
+  });
+});

--- a/frontend/e2e/tests/crc-dashboard.spec.js
+++ b/frontend/e2e/tests/crc-dashboard.spec.js
@@ -21,8 +21,8 @@ test.setTimeout(5 * 60 * 1000);
 
 async function deleteProject(page, projectId) {
   if (!projectId) return;
-  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
   try {
+    const token = await page.evaluate(() => localStorage.getItem("auth_token"));
     const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/frontend/e2e/tests/crc-full.spec.js
+++ b/frontend/e2e/tests/crc-full.spec.js
@@ -41,9 +41,20 @@ async function createWizardedProject(page, name) {
 async function deleteProject(page, projectId) {
   if (!projectId) return;
   const token = await page.evaluate(() => localStorage.getItem("auth_token"));
-  await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  }).catch((err) => console.error(`Failed to clean up project ${projectId}:`, err));
+  // Not thrown/asserted: this runs in a `finally` block, possibly after the
+  // test itself already failed, and a throw here would replace that
+  // original error rather than add to it. Logging loudly is enough to make
+  // a failed cleanup visible without masking the real failure.
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
 }
 
 test.describe("CRC assessment → report → dashboard", () => {
@@ -99,13 +110,6 @@ test.describe("CRC assessment → report → dashboard", () => {
   });
 
   test("mixed NA/Yes/No pattern → NA excluded from denominator, dashboard/report tier-label mismatch reproduces", async ({ page }) => {
-    // This test documents a known, still-open product bug (see the readiness
-    // dashboard bug list) and is expected to fail on its last assertion until
-    // that bug is fixed — test.fail() turns that expected failure into a
-    // passing run (and, crucially, into a build failure the day this
-    // unexpectedly starts passing, which is the signal the bug got fixed).
-    test.fail(true, "Known bug: dashboard getReadinessTier vs report getMaturityLabel disagree at boundary scores (e.g. 37.5% = 'Partially Ready' on the dashboard, 'Needs Attention' on the report)");
-
     const name = `E2E CRC Mixed ${Date.now()}`;
     const crc = new CrcPage(page);
     const crcDash = new CrcDashboardPage(page);
@@ -149,9 +153,13 @@ test.describe("CRC assessment → report → dashboard", () => {
         await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-mixed.png", fullPage: true });
 
         console.log(`[crc-tier-mismatch] report="${reportLabel}" dashboard="${dashLabel}" at 37.5%`);
-        // Asserts the two labels actually AGREE — this is the correct,
-        // desired behavior, and fails today because they don't. See the
-        // test.fail() call above for why that's the intended, tracked state.
+
+        // Asserts the two labels actually agree at the same score. Currently
+        // fails — dashboard's getReadinessTier and score-report-crc's
+        // getMaturityLabel use different thresholds/vocabulary, so 37.5%
+        // reads as "Partially Ready" on one and "Needs Attention" on the
+        // other. Left as a real, unmasked assertion on purpose: this should
+        // go red until that's fixed, and turn green on its own once it is.
         expect(
           dashLabel.includes("partially") === reportLabel.includes("needs attention"),
           `dashboard="${dashLabel}" vs report="${reportLabel}" — same 37.5% score, opposite framing`
@@ -239,10 +247,6 @@ test.describe("CRC assessment → report → dashboard", () => {
   });
 
   test("fresh project (wizard done, zero CRC answers): Quick Wins widget renders before the empty-state check", async ({ page }) => {
-    // See the test.fail() note on the tier-label-mismatch test above — same
-    // reasoning applies here for this known, still-open product bug.
-    test.fail(true, "Known bug: QuickWinsWidget renders unconditionally, before the CRC dashboard's hasResponses/empty-state check");
-
     const name = `E2E CRC QuickWins ${Date.now()}`;
     const crcDash = new CrcDashboardPage(page);
     let projectId;

--- a/frontend/e2e/tests/crc-full.spec.js
+++ b/frontend/e2e/tests/crc-full.spec.js
@@ -40,12 +40,12 @@ async function createWizardedProject(page, name) {
 // wrap their test body in try/finally and call this in the finally branch.
 async function deleteProject(page, projectId) {
   if (!projectId) return;
-  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
   // Not thrown/asserted: this runs in a `finally` block, possibly after the
   // test itself already failed, and a throw here would replace that
   // original error rather than add to it. Logging loudly is enough to make
   // a failed cleanup visible without masking the real failure.
   try {
+    const token = await page.evaluate(() => localStorage.getItem("auth_token"));
     const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/frontend/e2e/tests/crc-full.spec.js
+++ b/frontend/e2e/tests/crc-full.spec.js
@@ -9,7 +9,7 @@
 // wizard (which gates CRC) only requires a premium account, not a finished
 // AIMA assessment.
 const { test, expect } = require("@playwright/test");
-const { STORAGE_STATE } = require("../constants");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
 const { DashboardPage } = require("../pages/dashboard.page");
 const { PremiumFeaturesPage } = require("../pages/premium-features.page");
 const { CrcPage } = require("../pages/crc.page");
@@ -33,6 +33,19 @@ async function createWizardedProject(page, name) {
   return projectId;
 }
 
+// Every test creates its own project; this deletes it via a direct API call
+// regardless of whether the test passed or failed, so a failed run doesn't
+// leave the project behind (the dashboard's own delete flow is broken for
+// never-started projects — see vulnerability-assessment.spec.js). Callers
+// wrap their test body in try/finally and call this in the finally branch.
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch((err) => console.error(`Failed to clean up project ${projectId}:`, err));
+}
+
 test.describe("CRC assessment → report → dashboard", () => {
   test("all 'Yes' → 100% Ready/Strong, dashboard+report agree, PDF export works", async ({ page }) => {
     const name = `E2E CRC Yes ${Date.now()}`;
@@ -40,48 +53,59 @@ test.describe("CRC assessment → report → dashboard", () => {
     const crcDash = new CrcDashboardPage(page);
     let projectId;
 
-    await test.step("wizard + answer all 138 controls 'Yes'", async () => {
-      projectId = await createWizardedProject(page, name);
-      await crc.answerAllAndSubmit(projectId, "Yes");
-      await expect(page).toHaveURL(/score-report-crc/i);
-    });
+    try {
+      await test.step("wizard + answer all 138 controls 'Yes'", async () => {
+        projectId = await createWizardedProject(page, name);
+        await crc.answerAllAndSubmit(projectId, "Yes");
+        await expect(page).toHaveURL(/score-report-crc/i);
+      });
 
-    await test.step("report shows 100% and 'Strong'", async () => {
-      await expect(crc.reportSummaryHeading).toBeVisible();
-      await expect(crc.reportOverallReadiness).toBeVisible();
-      await expect(page.getByText(/100(\.0)?%/).first()).toBeVisible();
-      await expect(crc.reportMaturityLabel).toHaveText(/strong/i);
-      await page.screenshot({ path: "e2e/.artifacts/crc-report-100.png", fullPage: true });
-    });
+      await test.step("report shows 100% and 'Strong'", async () => {
+        await expect(crc.reportSummaryHeading).toBeVisible();
+        await expect(crc.reportOverallReadiness).toBeVisible();
+        await expect(page.getByText(/100(\.0)?%/).first()).toBeVisible();
+        await expect(crc.reportMaturityLabel).toHaveText(/strong/i);
+        await page.screenshot({ path: "e2e/.artifacts/crc-report-100.png", fullPage: true });
+      });
 
-    await test.step("dashboard agrees: 'Ready' tier, no Quick-Wins-before-data contradiction", async () => {
-      await crcDash.goto(projectId);
-      await expect(crcDash.tierBadge).toHaveText(/ready/i);
-      await expect(crcDash.noAssessmentData).toHaveCount(0); // fully answered, so this banner must NOT show
-      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-100.png", fullPage: true });
-    });
+      await test.step("dashboard agrees: 'Ready' tier, no Quick-Wins-before-data contradiction", async () => {
+        await crcDash.goto(projectId);
+        await expect(crcDash.tierBadge).toHaveText(/ready/i);
+        await expect(crcDash.noAssessmentData).toHaveCount(0); // fully answered, so this banner must NOT show
+        await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-100.png", fullPage: true });
+      });
 
-    await test.step("PDF export (Full + Summary) both succeed with no console errors", async () => {
-      const errors = [];
-      page.on("console", (msg) => { if (msg.type() === "error") errors.push(msg.text()); });
+      await test.step("PDF export (Full + Summary) both succeed with no console errors", async () => {
+        const errors = [];
+        page.on("console", (msg) => { if (msg.type() === "error") errors.push(msg.text()); });
 
-      const [download1] = await Promise.all([
-        page.waitForEvent("download", { timeout: 30_000 }),
-        crcDash.exportFullButton.click(),
-      ]);
-      expect(await download1.path()).toBeTruthy();
+        const [download1] = await Promise.all([
+          page.waitForEvent("download", { timeout: 30_000 }),
+          crcDash.exportFullButton.click(),
+        ]);
+        expect(await download1.path()).toBeTruthy();
 
-      const [download2] = await Promise.all([
-        page.waitForEvent("download", { timeout: 30_000 }),
-        crcDash.exportSummaryButton.click(),
-      ]);
-      expect(await download2.path()).toBeTruthy();
+        const [download2] = await Promise.all([
+          page.waitForEvent("download", { timeout: 30_000 }),
+          crcDash.exportSummaryButton.click(),
+        ]);
+        expect(await download2.path()).toBeTruthy();
 
-      expect(errors, `console errors during PDF export: ${errors.join(" | ")}`).toEqual([]);
-    });
+        expect(errors, `console errors during PDF export: ${errors.join(" | ")}`).toEqual([]);
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
   });
 
   test("mixed NA/Yes/No pattern → NA excluded from denominator, dashboard/report tier-label mismatch reproduces", async ({ page }) => {
+    // This test documents a known, still-open product bug (see the readiness
+    // dashboard bug list) and is expected to fail on its last assertion until
+    // that bug is fixed — test.fail() turns that expected failure into a
+    // passing run (and, crucially, into a build failure the day this
+    // unexpectedly starts passing, which is the signal the bug got fixed).
+    test.fail(true, "Known bug: dashboard getReadinessTier vs report getMaturityLabel disagree at boundary scores (e.g. 37.5% = 'Partially Ready' on the dashboard, 'Needs Attention' on the report)");
+
     const name = `E2E CRC Mixed ${Date.now()}`;
     const crc = new CrcPage(page);
     const crcDash = new CrcDashboardPage(page);
@@ -99,41 +123,43 @@ test.describe("CRC assessment → report → dashboard", () => {
       return "No";
     };
 
-    let total;
-    await test.step("wizard + answer with NA/Yes/No mix", async () => {
-      projectId = await createWizardedProject(page, name);
-      await crc.answerAllAndSubmit(projectId, pattern);
-      await expect(page).toHaveURL(/score-report-crc/i);
-    });
+    try {
+      await test.step("wizard + answer with NA/Yes/No mix", async () => {
+        projectId = await createWizardedProject(page, name);
+        await crc.answerAllAndSubmit(projectId, pattern);
+        await expect(page).toHaveURL(/score-report-crc/i);
+      });
 
-    await test.step("report reflects NA-excluded percentage, not raw yes-count/total", async () => {
-      await expect(crc.reportOverallReadiness).toBeVisible();
-      // naive (wrong) calc would be 48/138 = 34.8%; correct NA-excluded calc is 37.5%.
-      await expect(page.getByText(/37\.5%/).first()).toBeVisible();
-      await page.screenshot({ path: "e2e/.artifacts/crc-report-mixed.png", fullPage: true });
-    });
+      await test.step("report reflects NA-excluded percentage, not raw yes-count/total", async () => {
+        await expect(crc.reportOverallReadiness).toBeVisible();
+        // naive (wrong) calc would be 48/138 = 34.8%; correct NA-excluded calc is 37.5%.
+        await expect(page.getByText(/37\.5%/).first()).toBeVisible();
+        await page.screenshot({ path: "e2e/.artifacts/crc-report-mixed.png", fullPage: true });
+      });
 
-    let reportLabel;
-    await test.step("capture report maturity label", async () => {
-      reportLabel = (await crc.reportMaturityLabel.innerText()).trim().toLowerCase();
-    });
+      let reportLabel;
+      await test.step("capture report maturity label", async () => {
+        reportLabel = (await crc.reportMaturityLabel.innerText()).trim().toLowerCase();
+      });
 
-    await test.step("dashboard tier label vs report maturity label at 37.5%", async () => {
-      await crcDash.goto(projectId);
-      await expect(page.getByText(/37\.5%/).first()).toBeVisible();
-      const dashLabel = (await crcDash.tierBadge.innerText()).trim().toLowerCase();
-      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-mixed.png", fullPage: true });
+      await test.step("dashboard tier label vs report maturity label at 37.5%", async () => {
+        await crcDash.goto(projectId);
+        await expect(page.getByText(/37\.5%/).first()).toBeVisible();
+        const dashLabel = (await crcDash.tierBadge.innerText()).trim().toLowerCase();
+        await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-mixed.png", fullPage: true });
 
-      console.log(`[crc-tier-mismatch] report="${reportLabel}" dashboard="${dashLabel}" at 37.5%`);
-      // This assertion is EXPECTED TO FAIL while the bug is unfixed — dashboard
-      // says "partially ready" (mildly positive) while the report says "needs
-      // attention" (urgent) for the identical 37.5% score. A failure here is
-      // the live reproduction of the known bug, not a broken test.
-      expect(
-        dashLabel.includes("partially") === reportLabel.includes("needs attention"),
-        `dashboard="${dashLabel}" vs report="${reportLabel}" — same 37.5% score, opposite framing`
-      ).toBeFalsy();
-    });
+        console.log(`[crc-tier-mismatch] report="${reportLabel}" dashboard="${dashLabel}" at 37.5%`);
+        // Asserts the two labels actually AGREE — this is the correct,
+        // desired behavior, and fails today because they don't. See the
+        // test.fail() call above for why that's the intended, tracked state.
+        expect(
+          dashLabel.includes("partially") === reportLabel.includes("needs attention"),
+          `dashboard="${dashLabel}" vs report="${reportLabel}" — same 37.5% score, opposite framing`
+        ).toBeFalsy();
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
   });
 
   test("submit is blocked until all 138 controls are answered", async ({ page }) => {
@@ -141,81 +167,103 @@ test.describe("CRC assessment → report → dashboard", () => {
     const crc = new CrcPage(page);
     let projectId;
 
-    await test.step("wizard + answer only the first 5 controls", async () => {
-      projectId = await createWizardedProject(page, name);
-      await crc.gotoAssessment(projectId);
-      for (let i = 0; i < 5; i++) {
-        const before = await crc.counter.innerText();
-        await crc.answerOption("Yes").click();
-        await page.waitForTimeout(300);
-        await crc.nextButton.click();
-        await expect.poll(() => crc.counter.innerText(), { timeout: 15_000 }).not.toBe(before);
-      }
-    });
+    try {
+      await test.step("wizard + answer only the first 5 controls", async () => {
+        projectId = await createWizardedProject(page, name);
+        await crc.gotoAssessment(projectId);
+        for (let i = 0; i < 5; i++) {
+          const before = await crc.counter.innerText();
+          await crc.answerOption("Yes").click();
+          await page.waitForTimeout(300);
+          await crc.nextButton.click();
+          await expect.poll(() => crc.counter.innerText(), { timeout: 15_000 }).not.toBe(before);
+        }
+      });
 
-    await test.step("submit button stays disabled and reports the missing count", async () => {
-      await expect(crc.submitButton).toBeDisabled();
-      await expect(crc.submitBlockedReason).toHaveCount(1);
-      const title = await crc.submitBlockedReason.getAttribute("title");
-      expect(title).toMatch(/5\/138|answer all controls/i);
-    });
+      await test.step("submit button stays disabled and reports the missing count", async () => {
+        await expect(crc.submitButton).toBeDisabled();
+        await expect(crc.submitBlockedReason).toHaveCount(1);
+        const title = await crc.submitBlockedReason.getAttribute("title");
+        // Requires the actual "5/<total>" count, not just the generic phrase
+        // — the total isn't hardcoded to 138 (the published control count
+        // could change), but the numerator must be exactly 5 since that's
+        // exactly how many controls this test answered.
+        expect(title).toMatch(/5\/\d+/);
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
   });
 
   test("evidence tracker: blocked URL is rejected server-side, valid URL completes the audit-ready flow", async ({ page }) => {
     const name = `E2E CRC Evidence ${Date.now()}`;
     const crc = new CrcPage(page);
+    let projectId;
 
-    const projectId = await createWizardedProject(page, name);
-    await crc.gotoAssessment(projectId);
+    try {
+      projectId = await createWizardedProject(page, name);
+      await crc.gotoAssessment(projectId);
 
-    await test.step("answer the first control, then try a blocklisted evidence URL", async () => {
-      await crc.answerOption("Yes").click();
-      await page.waitForTimeout(400);
+      await test.step("answer the first control, then try a blocklisted evidence URL", async () => {
+        await crc.answerOption("Yes").click();
+        await page.waitForTimeout(400);
 
-      await crc.evidenceStatusSelect.selectOption("Evidence in Progress");
-      await page.waitForTimeout(300);
+        await crc.evidenceStatusSelect.selectOption("Evidence in Progress");
+        await page.waitForTimeout(300);
 
-      // google.com is on the backend's BLOCKED_DOMAINS list (validateEvidenceUrl
-      // in backend/src/routes/crc.ts) — the save should be rejected server-side
-      // and the input should roll back, not silently accept it.
-      await crc.evidenceUrlInput.fill("https://google.com");
-      await crc.evidenceUrlInput.press("Tab");
-      await expect(crc.blockedEvidenceUrlToast).toBeVisible({ timeout: 10_000 });
-      await expect(crc.evidenceUrlInput).toHaveValue("");
-      await expect(crc.auditReadyCheckbox).toHaveCount(0); // never appeared — no evidenceUrl was actually saved
-    });
+        // google.com is on the backend's BLOCKED_DOMAINS list (validateEvidenceUrl
+        // in backend/src/routes/crc.ts) — the save should be rejected server-side
+        // and the input should roll back, not silently accept it.
+        await crc.evidenceUrlInput.fill("https://google.com");
+        await crc.evidenceUrlInput.press("Tab");
+        await expect(crc.blockedEvidenceUrlToast).toBeVisible({ timeout: 10_000 });
+        await expect(crc.evidenceUrlInput).toHaveValue("");
+        await expect(crc.auditReadyCheckbox).toHaveCount(0); // never appeared — no evidenceUrl was actually saved
+      });
 
-    await test.step("a real evidence URL saves, and the audit-ready flow completes", async () => {
-      await crc.evidenceUrlInput.fill("https://docs.com");
-      await crc.evidenceUrlInput.press("Tab");
-      await expect(crc.evidenceUrlSavedToast).toBeVisible({ timeout: 10_000 });
+      await test.step("a real evidence URL saves, and the audit-ready flow completes", async () => {
+        await crc.evidenceUrlInput.fill("https://docs.com");
+        await crc.evidenceUrlInput.press("Tab");
+        await expect(crc.evidenceUrlSavedToast).toBeVisible({ timeout: 10_000 });
 
-      await crc.evidenceStatusSelect.selectOption("Evidence Complete");
-      await page.waitForTimeout(300);
+        await crc.evidenceStatusSelect.selectOption("Evidence Complete");
+        await page.waitForTimeout(300);
 
-      await expect(crc.auditReadyCheckbox).toBeVisible({ timeout: 10_000 });
-      await crc.auditReadyCheckbox.check();
-      await expect(crc.auditReadyCheckbox).toBeChecked();
-    });
+        await expect(crc.auditReadyCheckbox).toBeVisible({ timeout: 10_000 });
+        await crc.auditReadyCheckbox.check();
+        await expect(crc.auditReadyCheckbox).toBeChecked();
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
   });
 
   test("fresh project (wizard done, zero CRC answers): Quick Wins widget renders before the empty-state check", async ({ page }) => {
+    // See the test.fail() note on the tier-label-mismatch test above — same
+    // reasoning applies here for this known, still-open product bug.
+    test.fail(true, "Known bug: QuickWinsWidget renders unconditionally, before the CRC dashboard's hasResponses/empty-state check");
+
     const name = `E2E CRC QuickWins ${Date.now()}`;
     const crcDash = new CrcDashboardPage(page);
+    let projectId;
 
-    const projectId = await createWizardedProject(page, name);
+    try {
+      projectId = await createWizardedProject(page, name);
 
-    await crcDash.goto(projectId);
-    await expect(crcDash.noAssessmentData).toBeVisible();
+      await crcDash.goto(projectId);
+      await expect(crcDash.noAssessmentData).toBeVisible();
 
-    // Known bug: QuickWinsWidget renders unconditionally above the
-    // hasResponses check, so a zero-answer project shows recommended
-    // "quick wins" at the same time as "no assessment data yet" —
-    // contradictory framing.
-    const quickWinsVisible = await crcDash.quickWinsHeading.isVisible().catch(() => false);
-    await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-quickwins-bug.png", fullPage: true });
+      // Known bug: QuickWinsWidget renders unconditionally above the
+      // hasResponses check, so a zero-answer project shows recommended
+      // "quick wins" at the same time as "no assessment data yet" —
+      // contradictory framing.
+      const quickWinsVisible = await crcDash.quickWinsHeading.isVisible().catch(() => false);
+      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-quickwins-bug.png", fullPage: true });
 
-    console.log(`[crc-quickwins-bug] Quick Wins widget visible alongside empty state: ${quickWinsVisible}`);
-    expect(quickWinsVisible, "Quick Wins should NOT render before any CRC answers exist").toBeFalsy();
+      console.log(`[crc-quickwins-bug] Quick Wins widget visible alongside empty state: ${quickWinsVisible}`);
+      expect(quickWinsVisible, "Quick Wins should NOT render before any CRC answers exist").toBeFalsy();
+    } finally {
+      await deleteProject(page, projectId);
+    }
   });
 });

--- a/frontend/e2e/tests/crc-full.spec.js
+++ b/frontend/e2e/tests/crc-full.spec.js
@@ -1,0 +1,221 @@
+// Full CRC (Compliance Readiness Controls) module UI + logic e2e coverage.
+// Complements the disabled premium-feature/fully-compliant specs (all-Yes
+// only) with: a 100% run, a mixed run that mathematically reproduces the
+// known dashboard-vs-report tier-label mismatch, NA-exclusion-from-
+// denominator scoring, the incomplete-submit guard, the Quick-Wins-widget
+// empty-state bug on a zero-response project, and PDF export.
+//
+// Does not depend on AIMA being completed first — the AI System Profile
+// wizard (which gates CRC) only requires a premium account, not a finished
+// AIMA assessment.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { CrcPage } = require("../pages/crc.page");
+const { CrcDashboardPage } = require("../pages/crc-dashboard.page");
+
+test.use({ storageState: STORAGE_STATE });
+test.setTimeout(10 * 60 * 1000);
+
+// Creates a project and applies the AI System Profile wizard (unlocks CRC),
+// without touching AIMA. Returns the (possibly wizard-renamed) projectId.
+async function createWizardedProject(page, name) {
+  const dashboard = new DashboardPage(page);
+  const premiumFeatures = new PremiumFeaturesPage(page);
+
+  await dashboard.deleteProjectIfPresent(name);
+  await dashboard.createProject(name, "CRC e2e coverage project.");
+  const projectId = await dashboard.startAssessment(name);
+  expect(projectId).toBeTruthy();
+
+  await premiumFeatures.completeSystemProfileWizard(projectId, name);
+  return projectId;
+}
+
+test.describe("CRC assessment → report → dashboard", () => {
+  test("all 'Yes' → 100% Ready/Strong, dashboard+report agree, PDF export works", async ({ page }) => {
+    const name = `E2E CRC Yes ${Date.now()}`;
+    const crc = new CrcPage(page);
+    const crcDash = new CrcDashboardPage(page);
+    let projectId;
+
+    await test.step("wizard + answer all 138 controls 'Yes'", async () => {
+      projectId = await createWizardedProject(page, name);
+      await crc.answerAllAndSubmit(projectId, "Yes");
+      await expect(page).toHaveURL(/score-report-crc/i);
+    });
+
+    await test.step("report shows 100% and 'Strong'", async () => {
+      await expect(crc.reportSummaryHeading).toBeVisible();
+      await expect(crc.reportOverallReadiness).toBeVisible();
+      await expect(page.getByText(/100(\.0)?%/).first()).toBeVisible();
+      await expect(crc.reportMaturityLabel).toHaveText(/strong/i);
+      await page.screenshot({ path: "e2e/.artifacts/crc-report-100.png", fullPage: true });
+    });
+
+    await test.step("dashboard agrees: 'Ready' tier, no Quick-Wins-before-data contradiction", async () => {
+      await crcDash.goto(projectId);
+      await expect(crcDash.tierBadge).toHaveText(/ready/i);
+      await expect(crcDash.noAssessmentData).toHaveCount(0); // fully answered, so this banner must NOT show
+      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-100.png", fullPage: true });
+    });
+
+    await test.step("PDF export (Full + Summary) both succeed with no console errors", async () => {
+      const errors = [];
+      page.on("console", (msg) => { if (msg.type() === "error") errors.push(msg.text()); });
+
+      const [download1] = await Promise.all([
+        page.waitForEvent("download", { timeout: 30_000 }),
+        crcDash.exportFullButton.click(),
+      ]);
+      expect(await download1.path()).toBeTruthy();
+
+      const [download2] = await Promise.all([
+        page.waitForEvent("download", { timeout: 30_000 }),
+        crcDash.exportSummaryButton.click(),
+      ]);
+      expect(await download2.path()).toBeTruthy();
+
+      expect(errors, `console errors during PDF export: ${errors.join(" | ")}`).toEqual([]);
+    });
+  });
+
+  test("mixed NA/Yes/No pattern → NA excluded from denominator, dashboard/report tier-label mismatch reproduces", async ({ page }) => {
+    const name = `E2E CRC Mixed ${Date.now()}`;
+    const crc = new CrcPage(page);
+    const crcDash = new CrcDashboardPage(page);
+    let projectId;
+
+    // Controls 0-9 (10 total) = NA, next 48 = Yes, rest = No.
+    // Applicable = total - 10. With total=138: applicable=128, score=48/128=37.5%.
+    // 37.5% is in the boundary zone where the two pages disagree in tone:
+    // dashboard's getReadinessTier (30-59% = "Partially Ready", mildly
+    // positive) vs score-report-crc's getMaturityLabel (<40% = "Needs
+    // Attention", urgent) — see ross-server-readiness-dashboard-qa memory.
+    const pattern = (i) => {
+      if (i < 10) return "NA";
+      if (i < 58) return "Yes";
+      return "No";
+    };
+
+    let total;
+    await test.step("wizard + answer with NA/Yes/No mix", async () => {
+      projectId = await createWizardedProject(page, name);
+      await crc.answerAllAndSubmit(projectId, pattern);
+      await expect(page).toHaveURL(/score-report-crc/i);
+    });
+
+    await test.step("report reflects NA-excluded percentage, not raw yes-count/total", async () => {
+      await expect(crc.reportOverallReadiness).toBeVisible();
+      // naive (wrong) calc would be 48/138 = 34.8%; correct NA-excluded calc is 37.5%.
+      await expect(page.getByText(/37\.5%/).first()).toBeVisible();
+      await page.screenshot({ path: "e2e/.artifacts/crc-report-mixed.png", fullPage: true });
+    });
+
+    let reportLabel;
+    await test.step("capture report maturity label", async () => {
+      reportLabel = (await crc.reportMaturityLabel.innerText()).trim().toLowerCase();
+    });
+
+    await test.step("dashboard tier label vs report maturity label at 37.5%", async () => {
+      await crcDash.goto(projectId);
+      await expect(page.getByText(/37\.5%/).first()).toBeVisible();
+      const dashLabel = (await crcDash.tierBadge.innerText()).trim().toLowerCase();
+      await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-mixed.png", fullPage: true });
+
+      console.log(`[crc-tier-mismatch] report="${reportLabel}" dashboard="${dashLabel}" at 37.5%`);
+      // This assertion is EXPECTED TO FAIL while the bug is unfixed — dashboard
+      // says "partially ready" (mildly positive) while the report says "needs
+      // attention" (urgent) for the identical 37.5% score. A failure here is
+      // the live reproduction of the known bug, not a broken test.
+      expect(
+        dashLabel.includes("partially") === reportLabel.includes("needs attention"),
+        `dashboard="${dashLabel}" vs report="${reportLabel}" — same 37.5% score, opposite framing`
+      ).toBeFalsy();
+    });
+  });
+
+  test("submit is blocked until all 138 controls are answered", async ({ page }) => {
+    const name = `E2E CRC Partial ${Date.now()}`;
+    const crc = new CrcPage(page);
+    let projectId;
+
+    await test.step("wizard + answer only the first 5 controls", async () => {
+      projectId = await createWizardedProject(page, name);
+      await crc.gotoAssessment(projectId);
+      for (let i = 0; i < 5; i++) {
+        const before = await crc.counter.innerText();
+        await crc.answerOption("Yes").click();
+        await page.waitForTimeout(300);
+        await crc.nextButton.click();
+        await expect.poll(() => crc.counter.innerText(), { timeout: 15_000 }).not.toBe(before);
+      }
+    });
+
+    await test.step("submit button stays disabled and reports the missing count", async () => {
+      await expect(crc.submitButton).toBeDisabled();
+      await expect(crc.submitBlockedReason).toHaveCount(1);
+      const title = await crc.submitBlockedReason.getAttribute("title");
+      expect(title).toMatch(/5\/138|answer all controls/i);
+    });
+  });
+
+  test("evidence tracker: blocked URL is rejected server-side, valid URL completes the audit-ready flow", async ({ page }) => {
+    const name = `E2E CRC Evidence ${Date.now()}`;
+    const crc = new CrcPage(page);
+
+    const projectId = await createWizardedProject(page, name);
+    await crc.gotoAssessment(projectId);
+
+    await test.step("answer the first control, then try a blocklisted evidence URL", async () => {
+      await crc.answerOption("Yes").click();
+      await page.waitForTimeout(400);
+
+      await crc.evidenceStatusSelect.selectOption("Evidence in Progress");
+      await page.waitForTimeout(300);
+
+      // google.com is on the backend's BLOCKED_DOMAINS list (validateEvidenceUrl
+      // in backend/src/routes/crc.ts) — the save should be rejected server-side
+      // and the input should roll back, not silently accept it.
+      await crc.evidenceUrlInput.fill("https://google.com");
+      await crc.evidenceUrlInput.press("Tab");
+      await expect(crc.blockedEvidenceUrlToast).toBeVisible({ timeout: 10_000 });
+      await expect(crc.evidenceUrlInput).toHaveValue("");
+      await expect(crc.auditReadyCheckbox).toHaveCount(0); // never appeared — no evidenceUrl was actually saved
+    });
+
+    await test.step("a real evidence URL saves, and the audit-ready flow completes", async () => {
+      await crc.evidenceUrlInput.fill("https://docs.com");
+      await crc.evidenceUrlInput.press("Tab");
+      await expect(crc.evidenceUrlSavedToast).toBeVisible({ timeout: 10_000 });
+
+      await crc.evidenceStatusSelect.selectOption("Evidence Complete");
+      await page.waitForTimeout(300);
+
+      await expect(crc.auditReadyCheckbox).toBeVisible({ timeout: 10_000 });
+      await crc.auditReadyCheckbox.check();
+      await expect(crc.auditReadyCheckbox).toBeChecked();
+    });
+  });
+
+  test("fresh project (wizard done, zero CRC answers): Quick Wins widget renders before the empty-state check", async ({ page }) => {
+    const name = `E2E CRC QuickWins ${Date.now()}`;
+    const crcDash = new CrcDashboardPage(page);
+
+    const projectId = await createWizardedProject(page, name);
+
+    await crcDash.goto(projectId);
+    await expect(crcDash.noAssessmentData).toBeVisible();
+
+    // Known bug (ross-server-readiness-dashboard-qa memory): QuickWinsWidget
+    // renders unconditionally above the hasResponses check, so a zero-answer
+    // project shows recommended "quick wins" at the same time as "no
+    // assessment data yet" — contradictory framing.
+    const quickWinsVisible = await crcDash.quickWinsHeading.isVisible().catch(() => false);
+    await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-quickwins-bug.png", fullPage: true });
+
+    console.log(`[crc-quickwins-bug] Quick Wins widget visible alongside empty state: ${quickWinsVisible}`);
+    expect(quickWinsVisible, "Quick Wins should NOT render before any CRC answers exist").toBeFalsy();
+  });
+});

--- a/frontend/e2e/tests/crc-full.spec.js
+++ b/frontend/e2e/tests/crc-full.spec.js
@@ -92,7 +92,7 @@ test.describe("CRC assessment → report → dashboard", () => {
     // 37.5% is in the boundary zone where the two pages disagree in tone:
     // dashboard's getReadinessTier (30-59% = "Partially Ready", mildly
     // positive) vs score-report-crc's getMaturityLabel (<40% = "Needs
-    // Attention", urgent) — see ross-server-readiness-dashboard-qa memory.
+    // Attention", urgent).
     const pattern = (i) => {
       if (i < 10) return "NA";
       if (i < 58) return "Yes";
@@ -208,10 +208,10 @@ test.describe("CRC assessment → report → dashboard", () => {
     await crcDash.goto(projectId);
     await expect(crcDash.noAssessmentData).toBeVisible();
 
-    // Known bug (ross-server-readiness-dashboard-qa memory): QuickWinsWidget
-    // renders unconditionally above the hasResponses check, so a zero-answer
-    // project shows recommended "quick wins" at the same time as "no
-    // assessment data yet" — contradictory framing.
+    // Known bug: QuickWinsWidget renders unconditionally above the
+    // hasResponses check, so a zero-answer project shows recommended
+    // "quick wins" at the same time as "no assessment data yet" —
+    // contradictory framing.
     const quickWinsVisible = await crcDash.quickWinsHeading.isVisible().catch(() => false);
     await page.screenshot({ path: "e2e/.artifacts/crc-dashboard-quickwins-bug.png", fullPage: true });
 

--- a/frontend/e2e/tests/crc-pdf-export.spec.js
+++ b/frontend/e2e/tests/crc-pdf-export.spec.js
@@ -1,0 +1,38 @@
+// Quick standalone re-check of CRC dashboard PDF export, against the already
+// fully-answered (100%) project left behind by crc-full.spec.js's Yes run —
+// avoids re-walking all 138 controls just to test the export buttons.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE } = require("../constants");
+const { CrcDashboardPage } = require("../pages/crc-dashboard.page");
+
+test.use({ storageState: STORAGE_STATE });
+
+const PROJECT_ID = process.env.CRC_PDF_PROJECT_ID;
+
+test("CRC dashboard PDF export (Full + Summary) on a 100%-complete project", async ({ page }) => {
+  test.skip(!PROJECT_ID, "set CRC_PDF_PROJECT_ID to an existing fully-answered project id");
+  const crcDash = new CrcDashboardPage(page);
+  const errors = [];
+  page.on("console", (msg) => { if (msg.type() === "error") errors.push(msg.text()); });
+
+  await crcDash.goto(PROJECT_ID);
+  await expect(crcDash.tierBadge).toHaveText(/ready/i);
+
+  const [download1] = await Promise.all([
+    page.waitForEvent("download", { timeout: 30_000 }),
+    crcDash.exportFullButton.click(),
+  ]);
+  expect(await download1.path()).toBeTruthy();
+  console.log(`[crc-pdf] full export downloaded: ${download1.suggestedFilename()}`);
+
+  await page.waitForTimeout(1000);
+
+  const [download2] = await Promise.all([
+    page.waitForEvent("download", { timeout: 30_000 }),
+    crcDash.exportSummaryButton.click(),
+  ]);
+  expect(await download2.path()).toBeTruthy();
+  console.log(`[crc-pdf] summary export downloaded: ${download2.suggestedFilename()}`);
+
+  expect(errors, `console errors during PDF export: ${errors.join(" | ")}`).toEqual([]);
+});

--- a/frontend/e2e/tests/fairness-bias.spec.js
+++ b/frontend/e2e/tests/fairness-bias.spec.js
@@ -1,0 +1,200 @@
+// AI Bias & Fairness Testing (/assess/<id>/fairness-bias/*) — the one premium
+// feature the e2e README explicitly marked "out of scope; not attempted
+// here." This is the first pass: create a project, complete the AI System
+// Profile wizard (wizard-gated, same as CRC/vulnerability-assessment — see
+// isPremiumRoute in layout.tsx), and drive all three testing paths (Manual
+// Prompt Testing, API Automated Testing, Dataset Testing) end-to-end.
+//
+// Kept project, like premium-feature.spec.js's "Full Premium Feature": named
+// exactly "bias test" (not timestamped) so it stays easy to find and inspect
+// afterward. NOT deleted in a `finally` block on purpose.
+//
+// Bug under live investigation (see fairness-manual.page.js's class-level
+// comment for the code-level theory): the manual-prompt "report" page reached
+// via the natural job-completion redirect
+// (/fairness-bias/report?jobId=X) ignores jobId entirely and can show a
+// STALE response for a question that was re-answered in a later run, while
+// the separate Manual Test History detail view
+// (/fairness-bias/manual-history/<reportId>) is scoped correctly. This spec
+// answers the same question twice with distinguishable text to prove it live
+// rather than only by reading the code.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { FairnessOptionsPage } = require("../pages/fairness-options.page");
+const {
+  FairnessManualPage,
+  FairnessJobPage,
+  FairnessManualReportPage,
+  FairnessManualHistoryDetailPage,
+} = require("../pages/fairness-manual.page");
+const { FairnessApiEndpointPage, FairnessApiHistoryDetailPage, STEREOTYPED_RESPONSE } = require("../pages/fairness-api.page");
+const { FairnessDatasetPage, FairnessDatasetReportPage } = require("../pages/fairness-dataset.page");
+
+test.setTimeout(25 * 60 * 1000);
+
+test.use({ storageState: STORAGE_STATE });
+
+const PROJECT_NAME = "bias test";
+
+test.describe("AI Bias & Fairness Testing", () => {
+  test("manual prompt, API automated, and dataset testing paths end-to-end", async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    const premiumFeatures = new PremiumFeaturesPage(page);
+    const options = new FairnessOptionsPage(page);
+    const manual = new FairnessManualPage(page);
+    const manualReport = new FairnessManualReportPage(page);
+    const manualHistoryDetail = new FairnessManualHistoryDetailPage(page);
+    const apiEndpoint = new FairnessApiEndpointPage(page);
+    const apiHistoryDetail = new FairnessApiHistoryDetailPage(page);
+    const dataset = new FairnessDatasetPage(page);
+    const datasetReport = new FairnessDatasetReportPage(page);
+
+    let projectId;
+
+    await test.step("create the 'bias test' project", async () => {
+      await dashboard.createProject(PROJECT_NAME, "Bias & fairness testing QA pass.");
+      projectId = await dashboard.startAssessment(PROJECT_NAME);
+      expect(projectId).toBeTruthy();
+    });
+
+    await test.step("complete the AI System Profile wizard (unlocks fairness-bias)", async () => {
+      await premiumFeatures.completeSystemProfileWizard(projectId, PROJECT_NAME);
+    });
+
+    await test.step("Bias & Fairness Testing Options hub renders all three paths", async () => {
+      await options.goto(projectId);
+      await expect(options.manualCard).toBeVisible();
+      await expect(options.apiCard).toBeVisible();
+      await expect(options.datasetCard).toBeVisible();
+    });
+
+    let questionText;
+    await test.step("Manual Prompt Testing — run 1: answer the first question", async () => {
+      await manual.goto(projectId);
+      questionText = await manual.currentQuestionText.textContent();
+      await manual.answerCurrentQuestion(
+        "RUN-1 RESPONSE: Men and women are equally capable in any profession; hiring should be based on qualifications only."
+      );
+      const jobId = await manual.submit();
+      expect(jobId).toBeTruthy();
+
+      const job = new FairnessJobPage(page, `/assess/${projectId}/fairness-bias`);
+      const status = await job.waitForTerminalStatus();
+      expect(["completed", "success", "partial_success"]).toContain(status);
+
+      // BUG: the auto-redirect never fires here — see FairnessJobPage's
+      // clickViewReportManually() comment. Confirmed live twice (this run,
+      // and an isolated repro) waiting 85+ seconds past terminal status.
+      // Work around it by clicking "View report" manually so the rest of
+      // this spec can proceed.
+      await job.clickViewReportManually();
+      await page.waitForURL(/\/fairness-bias\/report\?jobId=/i, { timeout: 15_000 });
+      await manualReport.heading.waitFor({ timeout: 15_000 });
+      const shown = await manualReport.firstResponseText();
+      expect(shown, "run 1's report should show run 1's response").toContain("RUN-1 RESPONSE");
+    });
+
+    await test.step("Manual Prompt Testing — run 2: re-answer the SAME question differently", async () => {
+      await manual.goto(projectId);
+      const questionTextRun2 = await manual.currentQuestionText.textContent();
+      expect(questionTextRun2, "run 2 should land on the same question as run 1 (fresh page load resets to prompt 0)").toBe(questionText);
+
+      await manual.answerCurrentQuestion(
+        "RUN-2 RESPONSE: This is the updated answer that should replace run 1's response in any report scoped to this job."
+      );
+      const jobId2 = await manual.submit();
+      expect(jobId2).toBeTruthy();
+
+      const job = new FairnessJobPage(page, `/assess/${projectId}/fairness-bias`);
+      const status = await job.waitForTerminalStatus();
+      expect(["completed", "success", "partial_success"]).toContain(status);
+
+      await job.clickViewReportManually();
+      await page.waitForURL(/\/fairness-bias\/report\?jobId=/i, { timeout: 15_000 });
+      await manualReport.heading.waitFor({ timeout: 15_000 });
+      const shownAfterRun2 = await manualReport.firstResponseText();
+
+      // THE ACTUAL BUG CHECK: /fairness-bias/report?jobId=<jobId2> ignores
+      // jobId and rebuilds from ALL evaluations ever recorded for the
+      // project, keyed by category+questionText with .set() overwriting in
+      // newest-first iteration order — so the OLDEST evaluation for a
+      // repeated key wins. If that theory is right, this still shows RUN-1's
+      // text despite being reached via run 2's own completion redirect.
+      console.log(`[bias-test] /fairness-bias/report after run 2 shows: ${shownAfterRun2?.slice(0, 80)}`);
+      if (shownAfterRun2?.includes("RUN-1 RESPONSE")) {
+        console.log("[bias-test] CONFIRMED LIVE: report page shows stale (run 1) response after run 2 completed, and jobId query param had no effect.");
+      } else if (shownAfterRun2?.includes("RUN-2 RESPONSE")) {
+        console.log("[bias-test] Report page showed the fresh (run 2) response — staleness theory did not reproduce this time.");
+      }
+    });
+
+    await test.step("Manual Test History detail view — check 'Your Response' rendering", async () => {
+      await manual.goto(projectId);
+      await manual.historyHeading.scrollIntoViewIfNeeded();
+      await expect(manual.historyRows.first()).toBeVisible({ timeout: 15_000 });
+      await manual.historyRows.first().click();
+      await manualHistoryDetail.heading.waitFor({ timeout: 15_000 });
+      const shown = await manualHistoryDetail.firstResponseText();
+      console.log(`[bias-test] Manual Test History detail (latest row) 'Your Response' shows: ${shown?.slice(0, 80)}`);
+      // BUG (confirmed live): this always reads "N/A", never the actual
+      // submitted text. Root cause — evaluationAggregator in
+      // backend/src/inngest/functions.ts (~line 526) builds each persisted
+      // result as { category, prompt, success, evaluation, message } only;
+      // it never includes the user's response text under any field name.
+      // The frontend (manual-history/[reportId]/page.tsx ~line 293) reads
+      // `item.userResponse || item.response || "N/A"`, and since neither
+      // key is ever present, every report's "Your Response" section falls
+      // through to the literal string "N/A" — not specific to rerunning the
+      // same question, this is every Manual Prompt Testing report, always.
+      // Logged, not hard-asserted, so the remaining API/dataset legs run.
+      if (shown === "N/A") {
+        console.log("[bias-test] CONFIRMED: 'Your Response' is always N/A on the Manual Test History detail page — the submitted answer text is never persisted/returned by the backend.");
+      }
+    });
+
+    await test.step("API Automated Testing — configure and run against httpbin", async () => {
+      await apiEndpoint.goto(projectId);
+      await expect(apiEndpoint.heading).toBeVisible();
+      await apiEndpoint.configure();
+      await expect(apiEndpoint.startButton).toBeEnabled({ timeout: 15_000 });
+
+      const jobId = await apiEndpoint.startTest();
+      expect(jobId).toBeTruthy();
+
+      const job = new FairnessJobPage(page, `/assess/${projectId}/fairness-bias/api-endpoint`);
+      // 20 total fairness prompts at a 45s-per-request rate limit
+      // (EVALUATION_MIN_REQUEST_INTERVAL_MS) — up to ~15 minutes worst case.
+      const status = await job.waitForTerminalStatus(18 * 60 * 1000);
+      expect(["completed", "success", "partial_success"]).toContain(status);
+
+      await page.waitForURL(/\/fairness-bias\/api-history\/[\w-]+/i, { timeout: 30_000 });
+      await apiHistoryDetail.heading.waitFor({ timeout: 15_000 });
+
+      const overall = (await apiHistoryDetail.valueAfter(apiHistoryDetail.avgOverallScoreLabel).textContent())?.trim();
+      const bias = (await apiHistoryDetail.valueAfter(apiHistoryDetail.avgBiasScoreLabel).textContent())?.trim();
+      console.log(`[bias-test] API automated report — Avg Overall Score: ${overall}, Avg Bias Score: ${bias}`);
+      expect(overall, "Avg Overall Score should be a real percentage, not N/A (unlike the known SECURITY_SCAN average_scores bug)").not.toBe("N/A");
+      expect(bias, "Avg Bias Score should be a real percentage given every probe got the identical stereotyped response").not.toBe("N/A");
+    });
+
+    await test.step("Dataset Testing — upload a CSV with an unambiguous gender/outcome disparity", async () => {
+      await dataset.goto(projectId);
+      await dataset.uploadBiasedCsv();
+      await dataset.evaluate();
+
+      await datasetReport.waitFor();
+      const verdict = (await datasetReport.verdictLabel.textContent())?.trim();
+      console.log(`[bias-test] Dataset report overall verdict: ${verdict}`);
+      expect(verdict, "a 100%-approved-male / 0%-approved-female dataset should not verdict as fully fair").not.toMatch(/^fair$/i);
+
+      const noSensitive = await datasetReport.noSensitiveColumnsMessage.isVisible().catch(() => false);
+      expect(noSensitive, "the 'gender' column with a 100%/0% split should be detected as a sensitive column, not reported as insufficient data").toBe(false);
+
+      await page.screenshot({ path: "e2e/.artifacts/bias-test-dataset-report.png", fullPage: true });
+    });
+
+    console.log(`[bias test] DONE — project kept at /assess/${projectId} (not deleted, like premium-feature.spec.js's kept project).`);
+  });
+});

--- a/frontend/e2e/tests/inventory.spec.js
+++ b/frontend/e2e/tests/inventory.spec.js
@@ -1,0 +1,80 @@
+// AI Component Inventory (/assess/<id>/inventory) — wizard-gated premium
+// route (layout.tsx's isPremiumRoute set, same gate as CRC/vulnerability-
+// assessment; see [[ross-server-vuln-assessment-qa]]). Covers the core
+// add -> appears in table with the right risk badge -> delete loop; filters,
+// the vendor catalog dropdown, and the vendor-risk-assessment sub-flow
+// ("Feature C") are out of scope for this pass.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { InventoryPage } = require("../pages/inventory.page");
+
+test.use({ storageState: STORAGE_STATE });
+test.setTimeout(5 * 60 * 1000);
+
+async function createWizardedProject(page, name) {
+  const dashboard = new DashboardPage(page);
+  const premiumFeatures = new PremiumFeaturesPage(page);
+
+  await dashboard.deleteProjectIfPresent(name);
+  await dashboard.createProject(name, "Inventory e2e coverage project.");
+  const projectId = await dashboard.startAssessment(name);
+  expect(projectId).toBeTruthy();
+
+  await premiumFeatures.completeSystemProfileWizard(projectId, name);
+  return projectId;
+}
+
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
+}
+
+test.describe("AI Component Inventory", () => {
+  test("adding a default (OpenAI, no data processing) component shows it as Low risk, then it can be deleted", async ({ page }) => {
+    const name = `E2E Inventory ${Date.now()}`;
+    const inventory = new InventoryPage(page);
+    let projectId;
+
+    try {
+      await test.step("wizard + open a fresh (empty) inventory", async () => {
+        projectId = await createWizardedProject(page, name);
+        await inventory.goto(projectId);
+        await expect(inventory.emptyState).toBeVisible({ timeout: 15_000 });
+      });
+
+      await test.step("add a component using the form's OpenAI defaults + 'No Data Processing'", async () => {
+        await inventory.addDefaultComponent("Primary closed foundation LLM used for e2e coverage.");
+        await expect(inventory.savedToast).toBeVisible({ timeout: 10_000 });
+      });
+
+      await test.step("it renders in the table as OpenAI / Closed Foundation Model / Low risk", async () => {
+        const row = inventory.row("GPT");
+        await expect(row).toBeVisible({ timeout: 10_000 });
+        await expect(row).toContainText(/openai/i);
+        await expect(row).toContainText(/low/i);
+        await page.screenshot({ path: "e2e/.artifacts/inventory-component-added.png", fullPage: true });
+      });
+
+      await test.step("deleting it removes it from the table", async () => {
+        await inventory.deleteComponent("GPT");
+        await expect(inventory.deletedToast).toBeVisible({ timeout: 10_000 });
+        await expect(inventory.row("GPT")).toHaveCount(0);
+        await expect(inventory.emptyState).toBeVisible({ timeout: 10_000 });
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
+  });
+});

--- a/frontend/e2e/tests/manage-subscription.spec.js
+++ b/frontend/e2e/tests/manage-subscription.spec.js
@@ -1,0 +1,24 @@
+// Subscription & Billing (/manage-subscription) — read-only smoke coverage.
+// See ManageSubscriptionPage for why this deliberately never clicks
+// Upgrade/Cancel: those redirect into real Stripe billing against the shared
+// test account's actual subscription.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE } = require("../constants");
+const { ManageSubscriptionPage } = require("../pages/manage-subscription.page");
+
+test.use({ storageState: STORAGE_STATE });
+
+test.describe("Manage Subscription (read-only)", () => {
+  test("page loads with the current plan and FAQ sections, no console errors", async ({ page }) => {
+    const errors = [];
+    page.on("console", (msg) => { if (msg.type() === "error") errors.push(msg.text()); });
+
+    const sub = new ManageSubscriptionPage(page);
+    await sub.goto();
+
+    await expect(sub.heading).toBeVisible();
+    await expect(sub.faqHeading).toBeVisible();
+
+    expect(errors, `console errors on /manage-subscription: ${errors.join(" | ")}`).toEqual([]);
+  });
+});

--- a/frontend/e2e/tests/project-settings.spec.js
+++ b/frontend/e2e/tests/project-settings.spec.js
@@ -1,0 +1,58 @@
+// Project settings (/assess/<id>/settings) — the plain (non-premium-gated)
+// "Project Details" edit form, shared by every account tier. Not covered by
+// any existing spec; project-lifecycle.spec.js only exercises the dashboard's
+// own create/delete, never this page.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { ProjectSettingsPage } = require("../pages/project-settings.page");
+
+test.use({ storageState: STORAGE_STATE });
+
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
+}
+
+test.describe("Project settings", () => {
+  test("editing name and description persists across a reload", async ({ page }) => {
+    const originalName = `E2E Settings ${Date.now()}`;
+    const updatedName = `${originalName} (edited)`;
+    const updatedDescription = "Updated by the project-settings e2e spec.";
+    const dashboard = new DashboardPage(page);
+    const settings = new ProjectSettingsPage(page);
+    let projectId;
+
+    try {
+      await test.step("create a project and open its settings", async () => {
+        await dashboard.createProject(originalName, "created by e2e");
+        projectId = await dashboard.startAssessment(originalName);
+        expect(projectId).toBeTruthy();
+        await settings.goto(projectId);
+        await expect(settings.nameInput).toHaveValue(originalName);
+      });
+
+      await test.step("update name and description, toast confirms the save", async () => {
+        await settings.updateDetails({ name: updatedName, description: updatedDescription });
+      });
+
+      await test.step("the new values survive a reload (persisted server-side, not just local state)", async () => {
+        await page.reload({ waitUntil: "domcontentloaded" });
+        await expect(settings.nameInput).toHaveValue(updatedName, { timeout: 15_000 });
+        await expect(settings.descriptionInput).toHaveValue(updatedDescription);
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
+  });
+});

--- a/frontend/e2e/tests/team-invite.spec.js
+++ b/frontend/e2e/tests/team-invite.spec.js
@@ -1,0 +1,82 @@
+// Team management (/assess/<id>/team) + the /invite/accept landing page.
+//
+// The full loop (send an invite email -> open it in a second mailbox ->
+// accept/decline) needs a real second inbox this suite doesn't have, so it's
+// intentionally out of scope here (see README). What IS covered end-to-end
+// against the real backend: sending an invite, it showing up in the "Pending
+// & Declined Invitations" table with the chosen role, and revoking it — the
+// full lifecycle an owner can drive alone. /invite/accept itself is covered
+// for its two token-error states, which don't require ever sending mail.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { TeamPage } = require("../pages/team.page");
+const { InvitePage } = require("../pages/invite.page");
+
+test.use({ storageState: STORAGE_STATE });
+
+async function deleteProject(page, projectId) {
+  if (!projectId) return;
+  const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+  try {
+    const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok()) {
+      console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+    }
+  } catch (err) {
+    console.error(`Failed to clean up project ${projectId}:`, err);
+  }
+}
+
+test.describe("Team management", () => {
+  test("owner can invite a member with a chosen role, see it pending, then revoke it", async ({ page }) => {
+    const name = `E2E Team ${Date.now()}`;
+    const inviteEmail = `e2e-invite-${Date.now()}@example.com`;
+    const dashboard = new DashboardPage(page);
+    const team = new TeamPage(page);
+    let projectId;
+
+    try {
+      await test.step("create a project and open its Team page", async () => {
+        await dashboard.createProject(name, "team e2e coverage project.");
+        projectId = await dashboard.startAssessment(name);
+        expect(projectId).toBeTruthy();
+        await team.goto(projectId);
+        await expect(team.inviteHeading).toBeVisible({ timeout: 15_000 });
+      });
+
+      await test.step("send an invite with the Viewer role", async () => {
+        await team.invite(inviteEmail, "Viewer");
+        await expect(team.pendingInvitationsHeading).toBeVisible({ timeout: 15_000 });
+        const row = team.invitationRow(inviteEmail);
+        await expect(row).toBeVisible();
+        await expect(row).toContainText(/viewer/i);
+        await expect(row).toContainText(/pending/i);
+      });
+
+      await test.step("revoking removes it from the pending list", async () => {
+        await team.revokeInvitation(inviteEmail);
+        await expect(team.invitationRow(inviteEmail)).toHaveCount(0);
+      });
+    } finally {
+      await deleteProject(page, projectId);
+    }
+  });
+});
+
+test.describe("Invite acceptance landing page (/invite/accept)", () => {
+  test("no token shows the invalid-invitation error, not a crash", async ({ page }) => {
+    const invite = new InvitePage(page);
+    await invite.goto(null);
+    await expect(invite.invalidHeading).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/no invitation token provided/i)).toBeVisible();
+  });
+
+  test("a garbage/expired token shows the invalid-invitation error", async ({ page }) => {
+    const invite = new InvitePage(page);
+    await invite.goto("not-a-real-token-e2e");
+    await expect(invite.invalidHeading).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -1,0 +1,80 @@
+// AI Vulnerability Assessment: create a project, complete the AI System
+// Profile wizard (vulnerability-assessment is a wizard-gated premium route,
+// same as CRC — see WizardGateProvider / layout.tsx's isPremiumRoute),
+// configure a security-scan endpoint, and start the scan. Covers only up to
+// the scan starting (job status page reachable, status badge visible) — a
+// full run takes ~20 min against even a fast public endpoint, and the
+// pending-jobs list / scan-history score column are known-broken (see
+// ross-server-vuln-assessment-qa memory), so asserting through completion
+// and the history views is left for a follow-up spec.
+//
+// Uses a timestamped project name (like aima-report.spec.js's primary test),
+// not a fixed kept name: completing the AI System Profile wizard silently
+// renames the project to whatever name is typed into the wizard's "Name of
+// this AI system" field, so a fixed name doesn't survive being reused across
+// runs. The wizard is given the same timestamped name for traceability.
+//
+// The project is intentionally left behind, not deleted: as of 2026-07-14
+// the dashboard's delete flow is broken against the live deployment for any
+// never-started project (confirmed on the unrelated, pre-existing
+// project-lifecycle.spec.js too, not just here) — opening a card's menu and
+// clicking "Delete" instead lands on that same card's "Choose Your Path"
+// modal. Stray projects from this spec need manual/API cleanup until that's
+// fixed.
+const { test, expect } = require("@playwright/test");
+const { STORAGE_STATE } = require("../constants");
+const { DashboardPage } = require("../pages/dashboard.page");
+const { PremiumFeaturesPage } = require("../pages/premium-features.page");
+const { VulnerabilityAssessmentPage } = require("../pages/vulnerability-assessment.page");
+const { VulnerabilityJobPage } = require("../pages/vulnerability-job.page");
+
+test.setTimeout(3 * 60 * 1000);
+
+test.use({ storageState: STORAGE_STATE });
+
+test.describe("AI Vulnerability Assessment", () => {
+  test("configure an endpoint and start a security scan", async ({ page }) => {
+    const name = `E2E Vulnerability Assessment ${Date.now()}`;
+    const dashboard = new DashboardPage(page);
+    const premiumFeatures = new PremiumFeaturesPage(page);
+    const vulnAssessment = new VulnerabilityAssessmentPage(page);
+    const vulnJob = new VulnerabilityJobPage(page);
+
+    let projectId;
+
+    await test.step("create the project", async () => {
+      await dashboard.createProject(name, "Vulnerability assessment end-to-end test.");
+      projectId = await dashboard.startAssessment(name);
+      expect(projectId).toBeTruthy();
+    });
+
+    await test.step("complete the AI System Profile wizard (unlocks the scan tool)", async () => {
+      await premiumFeatures.completeSystemProfileWizard(projectId, name);
+    });
+
+    await test.step("configure the security-scan endpoint", async () => {
+      await vulnAssessment.goto(projectId);
+      await expect(vulnAssessment.heading).toBeVisible();
+      await vulnAssessment.configure();
+      await expect(vulnAssessment.runScanButton).toBeEnabled({ timeout: 15_000 });
+    });
+
+    await test.step("start the scan and land on the job page", async () => {
+      const jobId = await vulnAssessment.startScan();
+      expect(jobId).toBeTruthy();
+      await expect(vulnJob.jobIdLabel).toBeVisible();
+      await expect(vulnJob.statusBadge).toBeVisible({ timeout: 30_000 });
+
+      await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-job.png", fullPage: true });
+    });
+
+    // TODO (follow-up spec): wait for the job to reach a terminal status,
+    // verify the security scorecard, and cover the known bugs found during
+    // manual QA — "Show all pending jobs" never lists a completed scan
+    // (status filter excludes success/failed/partial_success), the
+    // Vulnerability Scan History table's Score column always reads "N/A",
+    // and PDF export throws on oklch() colors and fails silently. Also add
+    // cleanup (delete the project) once the dashboard's delete flow works
+    // again for never-started projects.
+  });
+});

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -7,13 +7,22 @@
 // scorecard, the pending-jobs list, the scan-history panel, and PDF export.
 //
 // Three bugs found during manual QA were fixed upstream
-// (pankaj3399/ross-server) and are exercised as regressions here: the
-// response analyzer flagging safe refusals as vulnerabilities, the
-// pending-jobs list's status filter excluding every real terminal/mid-flight
-// status, and PDF export throwing on oklch() colors. Not fixed upstream, and
-// intentionally NOT asserted on below: the "Vulnerability Scan History"
-// panel's Score column always reads "N/A" for security-scan rows (list
-// endpoint doesn't select the `results` column that holds `overall_score`).
+// (pankaj3399/ross-server) and are exercised as regressions here:
+// - PDF export throwing on oklch() colors (see the PDF-export step).
+// - The pending-jobs list's status filter excluding every real
+//   terminal/mid-flight status (see the pending-jobs-list step).
+// - The response analyzer flagging safe refusals as vulnerabilities: the
+//   default scan config (VulnerabilityAssessmentPage.configure()) points
+//   every probe at an identical, textbook-safe canned refusal (the same
+//   technique the original manual QA pass used to find the bug), so a
+//   correctly-fixed analyzer should score this scan high with the
+//   previously false-positive-prone categories all at 100% — see the
+//   scorecard-verification step.
+//
+// Not fixed upstream, and intentionally NOT asserted on below: the
+// "Vulnerability Scan History" panel's Score column always reads "N/A" for
+// security-scan rows (list endpoint doesn't select the `results` column
+// that holds `overall_score`).
 //
 // Uses a timestamped project name (like aima-report.spec.js's primary test),
 // not a fixed kept name: completing the AI System Profile wizard silently
@@ -29,10 +38,25 @@ const { VulnerabilityJobPage } = require("../pages/vulnerability-job.page");
 const { VulnerabilityReportPage } = require("../pages/vulnerability-report.page");
 const { VulnerabilityPendingJobsPage } = require("../pages/vulnerability-pending-jobs.page");
 
-// Generous ceiling for a real ~20 minute scan plus UI navigation overhead.
-test.setTimeout(28 * 60 * 1000);
+// The 25-minute terminal wait plus the 3-minute PDF-export wait alone add up
+// to 28 minutes — this needs real headroom beyond that for setup, the
+// wizard, navigation, assertions, and cleanup.
+test.setTimeout(35 * 60 * 1000);
 
 test.use({ storageState: STORAGE_STATE });
+
+// Categories the response analyzer used to flag on safe refusals before the
+// upstream fix (see ross-server-vuln-assessment-qa QA history) — a
+// correctly-fixed analyzer should score every one of these 100% against the
+// canned-refusal scan config.
+const PREVIOUSLY_FALSE_POSITIVE_CATEGORIES = [
+  "leakage",
+  "prompt_injection",
+  "tool_abuse",
+  "authz_tenant_escape",
+  "sensitive_pii_exfiltration",
+  "hallucinated_capability",
+];
 
 test.describe("AI Vulnerability Assessment", () => {
   test("run a security scan end-to-end and verify the scorecard, pending-jobs list, history panel, and PDF export", async ({ page }) => {
@@ -47,90 +71,104 @@ test.describe("AI Vulnerability Assessment", () => {
     let projectId;
     let jobId;
 
-    await test.step("create the project", async () => {
-      await dashboard.createProject(name, "Vulnerability assessment end-to-end test.");
-      projectId = await dashboard.startAssessment(name);
-      expect(projectId).toBeTruthy();
-    });
+    try {
+      await test.step("create the project", async () => {
+        await dashboard.createProject(name, "Vulnerability assessment end-to-end test.");
+        projectId = await dashboard.startAssessment(name);
+        expect(projectId).toBeTruthy();
+      });
 
-    await test.step("complete the AI System Profile wizard (unlocks the scan tool)", async () => {
-      await premiumFeatures.completeSystemProfileWizard(projectId, name);
-    });
+      await test.step("complete the AI System Profile wizard (unlocks the scan tool)", async () => {
+        await premiumFeatures.completeSystemProfileWizard(projectId, name);
+      });
 
-    await test.step("configure the security-scan endpoint", async () => {
-      await vulnAssessment.goto(projectId);
-      await expect(vulnAssessment.heading).toBeVisible();
-      await vulnAssessment.configure();
-      await expect(vulnAssessment.runScanButton).toBeEnabled({ timeout: 15_000 });
-    });
+      await test.step("configure the security-scan endpoint", async () => {
+        await vulnAssessment.goto(projectId);
+        await expect(vulnAssessment.heading).toBeVisible();
+        await vulnAssessment.configure();
+        await expect(vulnAssessment.runScanButton).toBeEnabled({ timeout: 15_000 });
+      });
 
-    await test.step("start the scan and land on the job page", async () => {
-      jobId = await vulnAssessment.startScan();
-      expect(jobId).toBeTruthy();
-      await expect(vulnJob.jobIdLabel).toBeVisible();
-      await expect(vulnJob.statusBadge).toBeVisible({ timeout: 30_000 });
+      await test.step("start the scan and land on the job page", async () => {
+        jobId = await vulnAssessment.startScan();
+        expect(jobId).toBeTruthy();
+        await expect(vulnJob.jobIdLabel).toBeVisible();
+        await expect(vulnJob.statusBadge).toBeVisible({ timeout: 30_000 });
 
-      await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-job.png", fullPage: true });
-    });
+        await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-job.png", fullPage: true });
+      });
 
-    await test.step("wait for the scan to finish and auto-redirect to the report", async () => {
-      const terminalStatus = await vulnJob.waitForTerminalStatus();
-      expect(["COMPLETED", "SUCCESS", "PARTIAL_SUCCESS", "FAILED"]).toContain(terminalStatus);
+      await test.step("wait for the scan to finish and auto-redirect to the report", async () => {
+        const terminalStatus = await vulnJob.waitForTerminalStatus();
+        expect(["COMPLETED", "SUCCESS", "PARTIAL_SUCCESS", "FAILED"]).toContain(terminalStatus);
 
-      // The job page auto-redirects ~1.5-13s after reaching a terminal
-      // status (it retries fetching the report id a few times).
-      await page.waitForURL(/\/vulnerability-assessment\/api-history\/[\w-]+/i, { timeout: 30_000 });
-    });
+        // The job page auto-redirects ~1.5-13s after reaching a terminal
+        // status (it retries fetching the report id a few times).
+        await page.waitForURL(/\/vulnerability-assessment\/api-history\/[\w-]+/i, { timeout: 30_000 });
+      });
 
-    await test.step("verify the security scorecard", async () => {
-      await vulnReport.waitFor();
-      await expect(vulnReport.overallScoreLabel).toBeVisible();
-      await expect(vulnReport.riskLevelLabel).toBeVisible();
-      await expect(vulnReport.riskBadge).toBeVisible();
+      await test.step("verify the security scorecard, including the safe-refusal regression check", async () => {
+        await vulnReport.waitFor();
+        await expect(vulnReport.overallScoreLabel).toBeVisible();
+        await expect(vulnReport.riskLevelLabel).toBeVisible();
+        await expect(vulnReport.riskBadge).toBeVisible();
+        await expect(vulnReport.categoryAnalysisHeading).toBeVisible();
+        await expect(vulnReport.detailedResultsHeading).toBeVisible();
 
-      const score = await vulnReport.overallScore();
-      expect(score).toBeGreaterThanOrEqual(0);
-      expect(score).toBeLessThanOrEqual(100);
+        // Every probe got the identical canned safe refusal (see
+        // VulnerabilityAssessmentPage.configure()), so a correctly-fixed
+        // analyzer should score this scan high overall...
+        const score = await vulnReport.overallScore();
+        expect(score).toBeGreaterThanOrEqual(0);
+        expect(score).toBeLessThanOrEqual(100);
+        expect(score, "overall score should be high against an all-safe-refusal scan").toBeGreaterThanOrEqual(80);
 
-      await expect(vulnReport.categoryAnalysisHeading).toBeVisible();
-      await expect(vulnReport.detailedResultsHeading).toBeVisible();
+        // ...and specifically must not flag the categories the analyzer used
+        // to false-positive on refusals before the upstream fix. Any of
+        // these scoring below 100% here is the false-positive bug back.
+        for (const category of PREVIOUSLY_FALSE_POSITIVE_CATEGORIES) {
+          const categoryScore = await vulnReport.categoryScore(category);
+          expect(categoryScore, `${category} should be 100% — a safe refusal must not be flagged`).toBe(100);
+        }
 
-      await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-report.png", fullPage: true });
-    });
+        await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-report.png", fullPage: true });
+      });
 
-    await test.step("export the report as PDF (regression: used to fail silently on oklch colors)", async () => {
-      const download = await vulnReport.exportPdf();
-      expect(download.suggestedFilename()).toMatch(/^security-scan-report-.+\.pdf$/i);
-    });
+      await test.step("export the report as PDF (regression: used to fail silently on oklch colors)", async () => {
+        const download = await vulnReport.exportPdf();
+        expect(download.suggestedFilename()).toMatch(/^security-scan-report-.+\.pdf$/i);
+      });
 
-    await test.step("verify the job now shows up as completed on the pending-jobs list (regression: status filter used to hide every terminal state)", async () => {
-      await pendingJobs.goto(projectId);
-      await pendingJobs.waitForJobInCompletedSection(jobId);
-    });
+      await test.step("verify the job now shows up as completed on the pending-jobs list (regression: status filter used to hide every terminal state)", async () => {
+        await pendingJobs.goto(projectId);
+        await pendingJobs.waitForJobInCompletedSection(jobId);
+      });
 
-    await test.step("verify the run appears in the Vulnerability Scan History panel", async () => {
-      await vulnAssessment.goto(projectId);
-      await expect(vulnAssessment.historyHeading).toBeVisible();
-      // Known limitation, not fixed upstream and intentionally not asserted
-      // on here: this row's Score column always reads "N/A" for
-      // security-scan reports (list endpoint doesn't select the `results`
-      // column). The row itself, and drilling into "View Details", both
-      // work correctly.
-      await expect(vulnAssessment.historyRow("httpbin.org")).toBeVisible();
-    });
-
-    await test.step("cleanup: delete the project via direct API call", async () => {
+      await test.step("verify the run appears in the Vulnerability Scan History panel", async () => {
+        await vulnAssessment.goto(projectId);
+        await expect(vulnAssessment.historyHeading).toBeVisible();
+        // Known limitation, not fixed upstream and intentionally not asserted
+        // on here: this row's Score column always reads "N/A" for
+        // security-scan reports (list endpoint doesn't select the `results`
+        // column). The row itself, and drilling into "View Details", both
+        // work correctly.
+        await expect(vulnAssessment.historyRow("httpbin.org")).toBeVisible();
+      });
+    } finally {
       // Not done through the dashboard UI: the delete flow is broken there
       // for any never-started project (opening a card's kebab menu →
       // "Delete" instead opens that same card's "Choose Your Path" modal) —
       // reproduced independently on the pre-existing, unrelated
       // project-lifecycle.spec.js too, so it's a live-app issue, not
-      // something this spec introduced.
-      const token = await page.evaluate(() => localStorage.getItem("auth_token"));
-      const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      expect(response.ok()).toBeTruthy();
-    });
+      // something this spec introduced. Run in `finally` so a failed scan,
+      // assertion, download, or timeout still doesn't leave the project
+      // behind.
+      if (projectId) {
+        const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+        await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }).catch((err) => console.error(`Failed to clean up project ${projectId}:`, err));
+      }
+    }
   });
 });

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -163,11 +163,21 @@ test.describe("AI Vulnerability Assessment", () => {
       // something this spec introduced. Run in `finally` so a failed scan,
       // assertion, download, or timeout still doesn't leave the project
       // behind.
+      // Not thrown/asserted: a throw here (this already runs in `finally`)
+      // would replace the original test failure rather than add to it.
+      // Logging loudly is enough to make a failed cleanup visible.
       if (projectId) {
-        const token = await page.evaluate(() => localStorage.getItem("auth_token"));
-        await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        }).catch((err) => console.error(`Failed to clean up project ${projectId}:`, err));
+        try {
+          const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+          const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!response.ok()) {
+            console.error(`Failed to clean up project ${projectId}: DELETE returned ${response.status()}`);
+          }
+        } catch (err) {
+          console.error(`Failed to clean up project ${projectId}:`, err);
+        }
       }
     }
   });

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -6,15 +6,14 @@
 // via EVALUATION_MIN_REQUEST_INTERVAL_MS), and verify the resulting security
 // scorecard, the pending-jobs list, the scan-history panel, and PDF export.
 //
-// Three bugs found during manual QA (see ross-server-vuln-assessment-qa
-// memory) were fixed upstream (pankaj3399/ross-server) since that session
-// and are exercised as regressions here: the response analyzer flagging
-// safe refusals as vulnerabilities, the pending-jobs list's status filter
-// excluding every real terminal/mid-flight status, and PDF export throwing
-// on oklch() colors. Not fixed upstream, and intentionally NOT asserted on
-// below: the "Vulnerability Scan History" panel's Score column always reads
-// "N/A" for security-scan rows (list endpoint doesn't select the `results`
-// column that holds `overall_score`) — see the memory for detail.
+// Three bugs found during manual QA were fixed upstream
+// (pankaj3399/ross-server) and are exercised as regressions here: the
+// response analyzer flagging safe refusals as vulnerabilities, the
+// pending-jobs list's status filter excluding every real terminal/mid-flight
+// status, and PDF export throwing on oklch() colors. Not fixed upstream, and
+// intentionally NOT asserted on below: the "Vulnerability Scan History"
+// panel's Score column always reads "N/A" for security-scan rows (list
+// endpoint doesn't select the `results` column that holds `overall_score`).
 //
 // Uses a timestamped project name (like aima-report.spec.js's primary test),
 // not a fixed kept name: completing the AI System Profile wizard silently
@@ -121,12 +120,12 @@ test.describe("AI Vulnerability Assessment", () => {
     });
 
     await test.step("cleanup: delete the project via direct API call", async () => {
-      // Not done through the dashboard UI: as of 2026-07-14 the delete flow
-      // is broken there for any never-started project (opening a card's
-      // kebab menu → "Delete" instead opens that same card's "Choose Your
-      // Path" modal) — reproduced independently on the pre-existing,
-      // unrelated project-lifecycle.spec.js too, so it's a live-app issue,
-      // not something this spec introduced. See ross-server-e2e memory.
+      // Not done through the dashboard UI: the delete flow is broken there
+      // for any never-started project (opening a card's kebab menu →
+      // "Delete" instead opens that same card's "Choose Your Path" modal) —
+      // reproduced independently on the pre-existing, unrelated
+      // project-lifecycle.spec.js too, so it's a live-app issue, not
+      // something this spec introduced.
       const token = await page.evaluate(() => localStorage.getItem("auth_token"));
       const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
         headers: { Authorization: `Bearer ${token}` },

--- a/frontend/e2e/tests/vulnerability-assessment.spec.js
+++ b/frontend/e2e/tests/vulnerability-assessment.spec.js
@@ -1,46 +1,52 @@
 // AI Vulnerability Assessment: create a project, complete the AI System
 // Profile wizard (vulnerability-assessment is a wizard-gated premium route,
 // same as CRC — see WizardGateProvider / layout.tsx's isPremiumRoute),
-// configure a security-scan endpoint, and start the scan. Covers only up to
-// the scan starting (job status page reachable, status badge visible) — a
-// full run takes ~20 min against even a fast public endpoint, and the
-// pending-jobs list / scan-history score column are known-broken (see
-// ross-server-vuln-assessment-qa memory), so asserting through completion
-// and the history views is left for a follow-up spec.
+// configure a security-scan endpoint, start the scan, wait for it to reach a
+// terminal status (~20 min against even a fast public endpoint, rate-limited
+// via EVALUATION_MIN_REQUEST_INTERVAL_MS), and verify the resulting security
+// scorecard, the pending-jobs list, the scan-history panel, and PDF export.
+//
+// Three bugs found during manual QA (see ross-server-vuln-assessment-qa
+// memory) were fixed upstream (pankaj3399/ross-server) since that session
+// and are exercised as regressions here: the response analyzer flagging
+// safe refusals as vulnerabilities, the pending-jobs list's status filter
+// excluding every real terminal/mid-flight status, and PDF export throwing
+// on oklch() colors. Not fixed upstream, and intentionally NOT asserted on
+// below: the "Vulnerability Scan History" panel's Score column always reads
+// "N/A" for security-scan rows (list endpoint doesn't select the `results`
+// column that holds `overall_score`) — see the memory for detail.
 //
 // Uses a timestamped project name (like aima-report.spec.js's primary test),
 // not a fixed kept name: completing the AI System Profile wizard silently
 // renames the project to whatever name is typed into the wizard's "Name of
 // this AI system" field, so a fixed name doesn't survive being reused across
 // runs. The wizard is given the same timestamped name for traceability.
-//
-// The project is intentionally left behind, not deleted: as of 2026-07-14
-// the dashboard's delete flow is broken against the live deployment for any
-// never-started project (confirmed on the unrelated, pre-existing
-// project-lifecycle.spec.js too, not just here) — opening a card's menu and
-// clicking "Delete" instead lands on that same card's "Choose Your Path"
-// modal. Stray projects from this spec need manual/API cleanup until that's
-// fixed.
 const { test, expect } = require("@playwright/test");
-const { STORAGE_STATE } = require("../constants");
+const { STORAGE_STATE, API_BASE_URL } = require("../constants");
 const { DashboardPage } = require("../pages/dashboard.page");
 const { PremiumFeaturesPage } = require("../pages/premium-features.page");
 const { VulnerabilityAssessmentPage } = require("../pages/vulnerability-assessment.page");
 const { VulnerabilityJobPage } = require("../pages/vulnerability-job.page");
+const { VulnerabilityReportPage } = require("../pages/vulnerability-report.page");
+const { VulnerabilityPendingJobsPage } = require("../pages/vulnerability-pending-jobs.page");
 
-test.setTimeout(3 * 60 * 1000);
+// Generous ceiling for a real ~20 minute scan plus UI navigation overhead.
+test.setTimeout(28 * 60 * 1000);
 
 test.use({ storageState: STORAGE_STATE });
 
 test.describe("AI Vulnerability Assessment", () => {
-  test("configure an endpoint and start a security scan", async ({ page }) => {
+  test("run a security scan end-to-end and verify the scorecard, pending-jobs list, history panel, and PDF export", async ({ page }) => {
     const name = `E2E Vulnerability Assessment ${Date.now()}`;
     const dashboard = new DashboardPage(page);
     const premiumFeatures = new PremiumFeaturesPage(page);
     const vulnAssessment = new VulnerabilityAssessmentPage(page);
     const vulnJob = new VulnerabilityJobPage(page);
+    const vulnReport = new VulnerabilityReportPage(page);
+    const pendingJobs = new VulnerabilityPendingJobsPage(page);
 
     let projectId;
+    let jobId;
 
     await test.step("create the project", async () => {
       await dashboard.createProject(name, "Vulnerability assessment end-to-end test.");
@@ -60,7 +66,7 @@ test.describe("AI Vulnerability Assessment", () => {
     });
 
     await test.step("start the scan and land on the job page", async () => {
-      const jobId = await vulnAssessment.startScan();
+      jobId = await vulnAssessment.startScan();
       expect(jobId).toBeTruthy();
       await expect(vulnJob.jobIdLabel).toBeVisible();
       await expect(vulnJob.statusBadge).toBeVisible({ timeout: 30_000 });
@@ -68,13 +74,64 @@ test.describe("AI Vulnerability Assessment", () => {
       await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-job.png", fullPage: true });
     });
 
-    // TODO (follow-up spec): wait for the job to reach a terminal status,
-    // verify the security scorecard, and cover the known bugs found during
-    // manual QA — "Show all pending jobs" never lists a completed scan
-    // (status filter excludes success/failed/partial_success), the
-    // Vulnerability Scan History table's Score column always reads "N/A",
-    // and PDF export throws on oklch() colors and fails silently. Also add
-    // cleanup (delete the project) once the dashboard's delete flow works
-    // again for never-started projects.
+    await test.step("wait for the scan to finish and auto-redirect to the report", async () => {
+      const terminalStatus = await vulnJob.waitForTerminalStatus();
+      expect(["COMPLETED", "SUCCESS", "PARTIAL_SUCCESS", "FAILED"]).toContain(terminalStatus);
+
+      // The job page auto-redirects ~1.5-13s after reaching a terminal
+      // status (it retries fetching the report id a few times).
+      await page.waitForURL(/\/vulnerability-assessment\/api-history\/[\w-]+/i, { timeout: 30_000 });
+    });
+
+    await test.step("verify the security scorecard", async () => {
+      await vulnReport.waitFor();
+      await expect(vulnReport.overallScoreLabel).toBeVisible();
+      await expect(vulnReport.riskLevelLabel).toBeVisible();
+      await expect(vulnReport.riskBadge).toBeVisible();
+
+      const score = await vulnReport.overallScore();
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+
+      await expect(vulnReport.categoryAnalysisHeading).toBeVisible();
+      await expect(vulnReport.detailedResultsHeading).toBeVisible();
+
+      await page.screenshot({ path: "e2e/.artifacts/vulnerability-scan-report.png", fullPage: true });
+    });
+
+    await test.step("export the report as PDF (regression: used to fail silently on oklch colors)", async () => {
+      const download = await vulnReport.exportPdf();
+      expect(download.suggestedFilename()).toMatch(/^security-scan-report-.+\.pdf$/i);
+    });
+
+    await test.step("verify the job now shows up as completed on the pending-jobs list (regression: status filter used to hide every terminal state)", async () => {
+      await pendingJobs.goto(projectId);
+      await pendingJobs.waitForJobInCompletedSection(jobId);
+    });
+
+    await test.step("verify the run appears in the Vulnerability Scan History panel", async () => {
+      await vulnAssessment.goto(projectId);
+      await expect(vulnAssessment.historyHeading).toBeVisible();
+      // Known limitation, not fixed upstream and intentionally not asserted
+      // on here: this row's Score column always reads "N/A" for
+      // security-scan reports (list endpoint doesn't select the `results`
+      // column). The row itself, and drilling into "View Details", both
+      // work correctly.
+      await expect(vulnAssessment.historyRow("httpbin.org")).toBeVisible();
+    });
+
+    await test.step("cleanup: delete the project via direct API call", async () => {
+      // Not done through the dashboard UI: as of 2026-07-14 the delete flow
+      // is broken there for any never-started project (opening a card's
+      // kebab menu → "Delete" instead opens that same card's "Choose Your
+      // Path" modal) — reproduced independently on the pre-existing,
+      // unrelated project-lifecycle.spec.js too, so it's a live-app issue,
+      // not something this spec introduced. See ross-server-e2e memory.
+      const token = await page.evaluate(() => localStorage.getItem("auth_token"));
+      const response = await page.request.delete(`${API_BASE_URL}/projects/${projectId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(response.ok()).toBeTruthy();
+    });
   });
 });

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -31,13 +31,18 @@ module.exports = defineConfig({
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
+    viewport: { width: 2560, height: 1440 },
   },
   projects: [
     { name: "setup", testMatch: /auth\.setup\.js/ },
     {
       name: "chromium",
       dependencies: ["setup"],
-      use: { ...devices["Desktop Chrome"] },
+      // devices["Desktop Chrome"] carries its own 1280x720 viewport, which
+      // would silently win over the global `use.viewport` above since
+      // project-level `use` is merged on top of it — so the 1440p viewport
+      // has to be reasserted here, after the spread, to actually apply.
+      use: { ...devices["Desktop Chrome"], viewport: { width: 2560, height: 1440 } },
     },
   ],
 

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -5,7 +5,9 @@ const path = require("path");
 
 require("dotenv").config({ path: path.join(__dirname, "e2e/.env.e2e") });
 
-const BASE_URL = process.env.E2E_BASE_URL || "https://ross-server-w14l.vercel.app";
+// Single source of truth: BASE_URL comes from e2e/constants.js (which reads
+// E2E_BASE_URL — see e2e/.env.e2e.example), not a literal duplicated here.
+const { BASE_URL } = require("./e2e/constants");
 
 module.exports = defineConfig({
   testDir: "./e2e",


### PR DESCRIPTION
PR description

## Summary
- Pulls in three fixes already landed on upstream (pankaj3399/ross-server main) that this fork's `setup`/`main` had missed: the security-scan response analyzer flagging safe refusals as vulnerabilities, the pending-jobs list's status filter hiding every real terminal/mid-flight scan status, and PDF export throwing silently on `oklch()` colors. No new product code was written for these — this is a merge, verified live against the deployed app before and after.
- Completes `vulnerability-assessment.spec.js`: previously stopped once a scan started; now runs the full lifecycle — wizard → configure → start scan → wait for a real terminal status (~20 min) → verify the scorecard (score/risk/category breakdown) → verify PDF export actually downloads → verify the job shows up on the pending-jobs list → verify the scan-history panel → cleanup via direct API delete.
- Completes the CRC e2e suite (`crc-full.spec.js`, `crc-pdf-export.spec.js`, `crc-dashboard.page.js`): 100%-Yes flow with PDF export, mixed NA/Yes/No scoring, submit-blocked guard, and a new test for the previously-uncovered evidence-tracker + evidence-URL blocklist flow (including the negative case — a blocked domain gets rejected server-side and rolls back).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded E2E coverage for CRC dashboards and reports, including full vs summary PDF export, readiness/evidence validation, and evidence URL rejection flows.
  * Added E2E coverage for AI Vulnerability Assessment scan lifecycle end-to-end: configuration, job start/terminal status, pending jobs, history, and PDF report export.
  * Added/expanded E2E scenarios for auth, account settings (including deleted project recovery), project settings, team invites & invite acceptance, inventory, subscription, and fairness-bias flows.
* **Documentation / Chores**
  * Updated E2E setup guidance with `API_BASE_URL` and centralized Playwright base URL sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->