### PR TITLE
fix: migrate crc_risks constraint to partial unique index and improve risk_code sequence synchronization logic

### DIFF
--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -2042,12 +2042,15 @@ router.post("/risks/:projectId", authenticateToken, async (req, res) => {
       if (maxVal === 0) {
         await client.query(`SELECT setval('crc_risks_seq', 1, false)`);
       } else {
-        await client.query(`SELECT setval('crc_risks_seq', $1, true)`, [maxVal]);
+        await client.query(`
+          SELECT setval('crc_risks_seq', $1, true)
+          WHERE $1 > (SELECT last_value FROM crc_risks_seq)
+        `, [maxVal]);
       }
 
       let insertedRow = null;
       let attempts = 0;
-      const maxAttempts = 5;
+      const maxAttempts = 10;
 
       while (!insertedRow && attempts < maxAttempts) {
         attempts++;
@@ -2077,10 +2080,12 @@ router.post("/risks/:projectId", authenticateToken, async (req, res) => {
         } catch (insertErr: any) {
           await client.query("ROLLBACK TO SAVEPOINT manual_risk_insert");
           if (insertErr?.code === "23505" && attempts < maxAttempts) {
-            await client.query(
-              `SELECT setval('crc_risks_seq', (SELECT MAX(NULLIF(regexp_replace(risk_code, '[^0-9]', '', 'g'), '')::bigint) + $1 FROM crc_risks))`,
-              [attempts]
-            );
+            await client.query(`
+              SELECT setval('crc_risks_seq', GREATEST(
+                (SELECT COALESCE(MAX(NULLIF(regexp_replace(risk_code, '[^0-9]', '', 'g'), '')::bigint), 0) FROM crc_risks),
+                (SELECT last_value FROM crc_risks_seq)
+              ), true)
+            `);
           } else {
             throw insertErr;
           }

--- a/backend/src/routes/crc.ts
+++ b/backend/src/routes/crc.ts
@@ -2044,7 +2044,8 @@ router.post("/risks/:projectId", authenticateToken, async (req, res) => {
       } else {
         await client.query(`
           SELECT setval('crc_risks_seq', $1, true)
-          WHERE $1 > (SELECT last_value FROM crc_risks_seq)
+          FROM crc_risks_seq s
+          WHERE $1 > s.last_value OR ($1 = s.last_value AND NOT s.is_called)
         `, [maxVal]);
       }
 
@@ -2079,7 +2080,11 @@ router.post("/risks/:projectId", authenticateToken, async (req, res) => {
           insertedRow = result.rows[0];
         } catch (insertErr: any) {
           await client.query("ROLLBACK TO SAVEPOINT manual_risk_insert");
-          if (insertErr?.code === "23505" && attempts < maxAttempts) {
+          const isRiskCodeConflict =
+            insertErr?.constraint === "crc_risks_risk_code_key" ||
+            Boolean(insertErr?.detail?.includes("risk_code"));
+
+          if (insertErr?.code === "23505" && isRiskCodeConflict && attempts < maxAttempts) {
             await client.query(`
               SELECT setval('crc_risks_seq', GREATEST(
                 (SELECT COALESCE(MAX(NULLIF(regexp_replace(risk_code, '[^0-9]', '', 'g'), '')::bigint), 0) FROM crc_risks),

--- a/backend/src/routes/wizard.ts
+++ b/backend/src/routes/wizard.ts
@@ -443,12 +443,12 @@ router.post("/:projectId/apply", authenticateToken, loadProject, requireProjectR
       // Global transaction-level lock to prevent concurrent rewinds of the sequence
       await client.query("SELECT pg_advisory_xact_lock(hashtext('crc_risks_seq_sync'))");
       await client.query(`
-        SELECT setval('crc_risks_seq', max_val)
+        SELECT setval('crc_risks_seq', max_val, true)
         FROM (
           SELECT COALESCE(MAX(NULLIF(regexp_replace(risk_code, '[^0-9]', '', 'g'), '')::bigint), 0) AS max_val 
           FROM crc_risks
-        ) m
-        WHERE max_val > (SELECT last_value FROM crc_risks_seq)
+        ) m, crc_risks_seq s
+        WHERE m.max_val > s.last_value OR (m.max_val = s.last_value AND NOT s.is_called)
       `);
     }
 


### PR DESCRIPTION
… r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating risks manually.
  * Reduced the likelihood of duplicate risk numbers during concurrent or repeated creations.
  * Added additional retry attempts to help recover from risk-number conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->